### PR TITLE
Update QuickCreds module line 117: change rm to rm -rf

### DIFF
--- a/modules/QuickCreds
+++ b/modules/QuickCreds
@@ -114,7 +114,7 @@ echo "Starting attack..." >> /root/loot/responder.log
 cd /root/loot
 dircount=$(ls -lad /root/loot/* | wc -l)
 mkdir /root/loot/$((dircount))
-rm /etc/turtle/Responder/logs
+rm -rf /etc/turtle/Responder/logs
 ln -s /root/loot/$((dircount)) /etc/turtle/Responder/logs
 
 # Stop dnsmasq


### PR DESCRIPTION
Updated QuickCreds module line 117: 
Previous version only used rm which caused an error since it was targeting a directory. (rm: '/etc/turtle/Responder/logs' is a directory). 
This caused further errors down the script and likely would cause issues past the first time the module was started.
