### PR TITLE
bugfix/pm_wrong_month_token

### DIFF
--- a/modules/ping-monitor
+++ b/modules/ping-monitor
@@ -62,7 +62,7 @@ function start_ping {
 }
 
 function move {
-  local dt="$(date +%Y%d%d-%H%M%S)"
+  local dt="$(date +%Y%m%d-%H%M%S)"
   local dp="/root/ping_monitor.${dt}"
 
   if [ -f ${sp} ]; then


### PR DESCRIPTION
Silly rookie mistake here and I'm not sure how I missed it to begin with. Anyway, this small change fixes an incorrect month token to the date command.