### PR TITLE
Fix quickcreds (Issue #34)

### DIFF
--- a/modules/quickcreds
+++ b/modules/quickcreds
@@ -1,6 +1,6 @@
 #!/bin/bash /usr/lib/turtle/turtle_module
 VERSION="1.3"
-DESCRIPTION="Snagging creds from locked machines --Mubix, Room362.com. Implements responder attack and saves creds to numbered directories in /root/loot. LED will blink rapidly while QuickCreds is running. Upon capture of NTLM hash the amber LED will light solid. Author: Hak5Darren. Credit: Mubix."
+DESCRIPTION="Snagging creds from locked machines --Mubix, Room362.com. Implements responder attack and saves creds to numbered directories in /root/loot. LED will blink while QuickCreds is running. Upon capture of NTLM hash the amber LED will light solid. Author: Hak5Darren. Credit: Mubix."
 CONF=/tmp/QuickCreds.form
 
 : ${DIALOG_OK=0}
@@ -125,10 +125,10 @@ if [ $(grep -v '\$:' /etc/turtle/Responder/logs/*NTLM* 2>/dev/null) ];
       finished
     fi
 fi
-    echo 255 > /sys/class/leds/lan-turtle\:orange\:system/brightness 2>&1
-    sleep 0.04
-    echo 0 > /sys/class/leds/lan-turtle\:orange\:system/brightness 2>&1
-    sleep 0.04
+    echo 255 > /sys/class/leds/turtle\:yellow\:system/brightness 2>&1
+    sleep 1
+    echo 0 > /sys/class/leds/turtle\:yellow\:system/brightness 2>&1
+    sleep 1
 done
 }
 


### PR DESCRIPTION
Hello,
When testing quickcreds, I faced 2 issues:
![image](https://user-images.githubusercontent.com/43848745/98449260-5a2e5780-2132-11eb-9c29-d42103ae9c5f.png)

- Blink 0.04 was not handled: changed to integer (so, no longer "rapidly")
- Orange led was missing: replace by "yellow", which seems to be the orange one...

It fixes both errors.

Regards,
jmkebalo