### PR TITLE
Fixed LED blinking.

### DIFF
--- a/modules/quickcreds
+++ b/modules/quickcreds
@@ -125,9 +125,9 @@ if [ $(grep -v '\$:' /etc/turtle/Responder/logs/*NTLM* 2>/dev/null) ];
       finished
     fi
 fi
-    echo 255 > /sys/class/leds/turtle\:yellow\:system/brightness 2>&1
+    echo 255 > /sys/class/leds/lan-turtle\:orange\:system/brightness 2>&1
     sleep 1
-    echo 0 > /sys/class/leds/turtle\:yellow\:system/brightness 2>&1
+    echo 0 > /sys/class/leds/lan-turtle\:orange\:system/brightness 2>&1
     sleep 1
 done
 }


### PR DESCRIPTION
Noticed earlier when running this script that it wasn't blinking the LED properly on my turtle and I was getting warnings about the earlier LED path not being valid. So instead I looked around in a similar path when i found that `/sys/class/leds/lan-turtle\:orange\:system/brightness` was valid.