### PR TITLE
Update nmap-scan

### DIFF
--- a/modules/nmap-scan
+++ b/modules/nmap-scan
@@ -1,5 +1,5 @@
 #!/bin/bash /usr/lib/turtle/turtle_module
-VERSION="1.0"
+VERSION="1.1"
 DESCRIPTION="Network Mapper discovers hosts and services on a network"
 CONF=/tmp/blank.form
 OUTPUT=/tmp/nmap.out
@@ -159,7 +159,7 @@ function profile {
 }
 
 function log {
-LOG=$(dialog --title "Select a directory to store the nmap log" --stdout --title "Select nmap log directory" --dselect / 18 60)
+LOG=$(dialog --title "Select a directory to store the nmap log" --stdout --title "Select nmap log directory" --dselect / 14 60)
 if [ -d $LOG ]; then
   uci set nmap.log="$LOG"
   uci commit nmap


### PR DESCRIPTION
Updated the dselect height for setting the log path.  The original setting was too large for a default putty screen and was preventing a user from setting the log path.