### PR TITLE
New Module: extroot

### DIFF
--- a/modules/extroot
+++ b/modules/extroot
@@ -23,6 +23,19 @@ CONF=/tmp/extroot.form
 : ${DIALOG_ESC=255}
 
 function configure {
+    /usr/bin/dialog --title "Extroot: Info" --msgbox "::: NOTICE :::\n\nThis module is intended for use on freshly-imaged devices. Any customizations already made are not guaranteed to persist through extroot configuration." 14 72
+
+    /usr/bin/dialog --title "Extroot: WARNING" --defaultno --yesno "::: WARNING :::\n\n\nThis Operation WILL ERASE THE ATTACHED SD CARD \n\nAre you sure you wish to continue?" 14 72
+
+    return=$?
+    case $return in
+      $DIALOG_OK)
+        perform_migration;;
+      $DIALOG_CANCEL)
+        /usr/bin/dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
+      $DIALOG_ESC)
+        /usr/bin/dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
+    esac
 }
 
 function check_network {
@@ -145,4 +158,5 @@ function perform_migration {
 }
 
 function start {
+    echo "This module is used via the 'Configure' option"
 }

--- a/modules/extroot
+++ b/modules/extroot
@@ -8,8 +8,10 @@
 # Target:        N/A
 # Attackmodes:   N/A
 
+# Constants
 VERSION="1.0"
 DESCRIPTION="Simplified SD card storage"
+REQUIRED_PACKAGES="block-mount kmod-fs-ext4 e2fsprogs fdisk"
 CONF=/tmp/extroot.form
 
 # All "dialog" functionality is related to the Turtle shell
@@ -21,6 +23,125 @@ CONF=/tmp/extroot.form
 : ${DIALOG_ESC=255}
 
 function configure {
+}
+
+function check_network {
+    # Check for Internet connection by attempting to contact an opkg repository server
+
+    # First, extract a server URL from distfeeds.conf
+    opkg_baseurl=$(sed -E -n "s/^[^#]*(http:\/\/[^\/]*)\/.*/\1/p;q" /etc/opkg/distfeeds.conf) &> /dev/null
+    if [[ $? -ne 0 ]]; then
+        /usr/bin/dialog --title "Extroot" --msgbox "\nCould not extract an opkg repo from distfeeds.conf\n\nIf this is unexpected, you may need to upgrade or restore the firmware." 9 72
+        exit 1
+    fi
+
+    # ...then, use wget to determine if the server can be reached
+    wget -q --spider "$opkg_baseurl" &> /dev/null
+    if [[ $? -ne 0 ]]; then
+        /usr/bin/dialog --title "Extroot" --msgbox "\nThe LAN Turtle could not connect to $output\nPlease connect the LAN Turtle to the Internet and try again." 9 72
+        exit 1
+    fi
+}
+
+function install_dependencies {
+    /bin/opkg update | /usr/bin/dialog --progressbox "Updating opkg" 14 72
+
+    /bin/opkg install $REQUIRED_PACKAGES | /usr/bin/dialog --progressbox "Checking/installing dependencies" 14 72
+}
+
+function remount_rootfsdata {
+    #TODO: Add sanity check for the overlay having already been migrated
+
+    # Identify flash memory device containing current overlay
+    rootfsdata_dev="$(sed -n -e "/\s\/overlay\s.*$/s///p" /etc/mtab)"
+
+    # Create remount entry
+    uci -q delete fstab.rwm
+    uci set fstab.rwm="mount"
+    uci set fstab.rwm.device="${rootfsdata_dev}"
+    uci set fstab.rwm.target="/rwm"
+    uci commit fstab
+}
+
+function format_sdcard {
+    # Identify our storage device
+    sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)
+
+    # Check SD card presence
+    [[ "$(ls /dev/sd* 2> /dev/null | wc -l)" == "0" ]] && {
+        echo "No SD card inserted or device not supported"
+        exit 1
+    }
+
+    # Unmount storage as applicable
+    block umount &> /dev/null
+
+    # Partition SD card for storage and swap
+    echo -e "o\nn\np\n2\n\n+1024M\nn\np\n1\n\np\n\nw\n" | fdisk $sdcard_device
+    echo y | mkfs.ext4 ${sdcard_device}1
+    mkswap ${sdcard_device}2
+
+    # Restart the storage bus
+    echo "1-0:1.0" > /sys/bus/usb/drivers/hub/unbind
+    echo "1-0:1.0" > /sys/bus/usb/drivers/hub/bind
+    sleep 3
+
+    # Commit/activate swap and remove existing SD card mounts
+    block detect > /etc/config/fstab
+    uci -q delete fstab.@mount[0]
+    uci commit fstab
+    block mount &> /dev/null
+}
+
+function make_extroot {
+    # Identify our storage partition
+    sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)1
+
+    # Identify the partition's UUID
+    eval $(block info ${sdcard_device} | grep -o -e "UUID=\S*")
+
+    # Delete and recreate the overlay fstab entry
+    uci -q delete fstab.overlay
+    uci set fstab.overlay="mount"
+    uci set fstab.overlay.uuid="${UUID}"
+    uci set fstab.overlay.target="/overlay"
+    uci commit fstab
+}
+
+function migrate_overlay {
+    # Identify our storage partition
+    sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)1
+
+    # Create a temporary mount point directory
+    mkdir -p /tmp/cproot
+
+    # Bind the current overlay to the mount point
+    mount --bind /overlay /tmp/cproot
+
+    # Mount the new overlay storage
+    mount ${sdcard_device} /mount
+
+    # Copy over the data
+    tar -C /tmp/cproot -cvf - . | tar -C /mnt -xf -	
+
+    # Unmount the new overlay and temporary mount point
+    umount /tmp/cproot /mnt
+}
+
+function perform_migration {
+    check_network
+
+    install_dependencies
+
+    remount_rootfsdata
+
+    format_sdcard
+
+    make_extroot
+
+    migrate_overlay
+
+    reboot
 }
 
 function start {

--- a/modules/extroot
+++ b/modules/extroot
@@ -32,10 +32,35 @@ function configure {
       $DIALOG_OK)
         perform_migration;;
       $DIALOG_CANCEL)
-        dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
+        dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
+        exit 0;;
       $DIALOG_ESC)
-        dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
+        dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
+        exit 0;;
     esac
+}
+
+function check_space {
+    # Get block size for the root partition
+    rootfs_blocksize=$(df -P / | awk '{print $2}' | tail -n+2)
+    rootfs_humansize=$(df -h / | awk '{print $2}' | tail -n+2)
+
+    # Check if the root partition is larger than 256 MB
+    if (( $rootfs_blocksize > 256000 )); then
+        dialog --title "Extroot: WARNING" --defaultno --yesno "::: WARNING :::\n\n\nThe root partition appears to be larger than 256MB in size (Seen: $rootfs_humansize)\n\nThis may indicate that the overlay configuration process has already been performed on this installation.\n\nAre you sure you wish to continue?" 14 72
+        
+        return=$?
+        case $return in
+          $DIALOG_OK)
+            return 0;;
+          $DIALOG_CANCEL)
+            dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
+            exit 0;;
+          $DIALOG_ESC)
+            dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
+            exit 0;;
+        esac
+    fi
 }
 
 function check_network {
@@ -68,8 +93,6 @@ function install_dependencies {
 }
 
 function remount_rootfsdata {
-    #TODO: Add sanity check for the overlay having already been migrated
-
     # Identify flash memory device containing current overlay
     rootfsdata_dev="$(sed -n -e "/\s\/overlay\s.*$/s///p" /etc/mtab)"
 
@@ -183,6 +206,7 @@ function perform_step {
 }
 
 function perform_migration {
+    check_space
 
     perform_step "check_network" "Checking network connectivity"
 

--- a/modules/extroot
+++ b/modules/extroot
@@ -1,0 +1,27 @@
+#!/bin/bash /usr/lib/turtle/turtle_module
+# Title:         LANTurtle OpenWRT Extroot configuration
+# Description:   Simplified SD card storage
+# Author:        jrwimmer
+# Props:         ImNatho, mike111b, madbuda
+# Version:       1.0
+# Category:      General
+# Target:        N/A
+# Attackmodes:   N/A
+
+VERSION="1.0"
+DESCRIPTION="Simplified SD card storage"
+CONF=/tmp/extroot.form
+
+# All "dialog" functionality is related to the Turtle shell
+: ${DIALOG_OK=0}
+: ${DIALOG_CANCEL=1}
+: ${DIALOG_HELP=2}
+: ${DIALOG_EXTRA=3}
+: ${DIALOG_ITEM_HELP=4}
+: ${DIALOG_ESC=255}
+
+function configure {
+}
+
+function start {
+}

--- a/modules/extroot
+++ b/modules/extroot
@@ -2,7 +2,7 @@
 # Title:         LANTurtle OpenWRT Extroot configuration
 # Description:   Simplified SD card storage
 # Author:        jrwimmer
-# Props:         ImNatho, mike111b, madbuda
+# Props:         The OpenWrt community
 # Version:       1.0
 # Category:      General
 # Target:        N/A

--- a/modules/extroot
+++ b/modules/extroot
@@ -44,22 +44,27 @@ function check_network {
     # First, extract a server URL from distfeeds.conf
     opkg_baseurl=$(sed -E -n "s/^[^#]*(http:\/\/[^\/]*)\/.*/\1/p;q" /etc/opkg/distfeeds.conf) &> /dev/null
     if [[ $? -ne 0 ]]; then
-        /usr/bin/dialog --title "Extroot" --msgbox "\nCould not extract an opkg repo from distfeeds.conf\n\nIf this is unexpected, you may need to upgrade or restore the firmware." 9 72
-        exit 1
+        echo "\nCould not extract an opkg repo from distfeeds.conf\n\nIf this is unexpected, you may need to upgrade or restore the firmware." > $1
+        return 1
     fi
 
     # ...then, use wget to determine if the server can be reached
-    wget -q --spider "$opkg_baseurl" &> /dev/null
-    if [[ $? -ne 0 ]]; then
-        /usr/bin/dialog --title "Extroot" --msgbox "\nThe LAN Turtle could not connect to $output\nPlease connect the LAN Turtle to the Internet and try again." 9 72
-        exit 1
+    wget -q --tries 3 --spider "$opkg_baseurl" &> /dev/null
+    wget_returncode=$?
+    if [[ $wget_returncode -ne 0 ]]; then
+        echo "\nLAN Turtle could not connect to $opkg_baseurl\nVerify the device's internet connection and try again (wget error $wget_returncode)" > $1
+        return 1
     fi
 }
 
 function install_dependencies {
-    /bin/opkg update | /usr/bin/dialog --progressbox "Updating opkg" 14 72
+    echo "Updating opkg"
+    /bin/opkg update
 
-    /bin/opkg install $REQUIRED_PACKAGES | /usr/bin/dialog --progressbox "Checking/installing dependencies" 14 72
+    echo "Checking/installing dependencies"
+    /bin/opkg install $REQUIRED_PACKAGES
+
+    sleep 3
 }
 
 function remount_rootfsdata {
@@ -74,87 +79,124 @@ function remount_rootfsdata {
     uci set fstab.rwm.device="${rootfsdata_dev}"
     uci set fstab.rwm.target="/rwm"
     uci commit fstab
+
+    sleep 3
 }
 
 function format_sdcard {
-    # Identify our storage device
-    sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)
-
-    # Check SD card presence
+    echo "Checking SD card presence"
     [[ "$(ls /dev/sd* 2> /dev/null | wc -l)" == "0" ]] && {
-        echo "No SD card inserted or device not supported"
-        exit 1
+        echo "\nError: No SD card is inserted or the card is not supported\n\nAdditional Details:\nCould not find a device with prefix 'sd'" > $1
+        return 1
     }
 
-    # Unmount storage as applicable
+    sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)
+    echo "New overlay device identified as: $sdcard_device"
+
+    echo "Unmounting any active external storage"
     block umount &> /dev/null
 
-    # Partition SD card for storage and swap
-    echo -e "o\nn\np\n2\n\n+1024M\nn\np\n1\n\np\n\nw\n" | fdisk $sdcard_device
-    echo y | mkfs.ext4 ${sdcard_device}1
+    echo "Partitioning SD card"
+    echo -e "o\nn\np\n2\n\n+1024M\nn\np\n1\n\np\n\nw\n" | fdisk $sdcard_device 2>/dev/null
+    mkfs.ext4 -F ${sdcard_device}1
     mkswap ${sdcard_device}2
 
-    # Restart the storage bus
-    echo "1-0:1.0" > /sys/bus/usb/drivers/hub/unbind
-    echo "1-0:1.0" > /sys/bus/usb/drivers/hub/bind
+    echo "Restarting the storage bus"
+    echo "1-0:1.0" > /sys/bus/usb/drivers/hub/unbind 2>/dev/null
+    echo "1-0:1.0" > /sys/bus/usb/drivers/hub/bind 2>/dev/null
     sleep 3
 
-    # Commit/activate swap and remove existing SD card mounts
+    echo "Commit/activate swap and remove existing SD card mounts"
     block detect > /etc/config/fstab
     uci -q delete fstab.@mount[0]
     uci commit fstab
     block mount &> /dev/null
+
+    sleep 3
 }
 
 function make_extroot {
-    # Identify our storage partition
     sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)1
+    echo "New overlay partition identified as: $sdcard_device"
 
-    # Identify the partition's UUID
     eval $(block info ${sdcard_device} | grep -o -e "UUID=\S*")
+    echo "New overlay partition has a UUID of: $UUID"
 
-    # Delete and recreate the overlay fstab entry
+    echo "Recreating overlay fstab entry"
     uci -q delete fstab.overlay
     uci set fstab.overlay="mount"
     uci set fstab.overlay.uuid="${UUID}"
     uci set fstab.overlay.target="/overlay"
     uci commit fstab
+
+    sleep 3
 }
 
 function migrate_overlay {
-    # Identify our storage partition
     sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)1
+    echo "New overlay partition identified as: $sdcard_device"
 
-    # Create a temporary mount point directory
+    echo "Creating temporary mount point directory at: /tmp/cproot"
     mkdir -p /tmp/cproot
 
-    # Bind the current overlay to the mount point
+    echo "Binding active overlay to: /tmp/cproot"
     mount --bind /overlay /tmp/cproot
 
-    # Mount the new overlay storage
-    mount ${sdcard_device} /mount
+    echo "Mounting new overlay parition at: /mnt"
+    mount ${sdcard_device} /mnt
 
-    # Copy over the data
-    tar -C /tmp/cproot -cvf - . | tar -C /mnt -xf -	
+    echo "Copying data; please wait..."
+    tar -C /tmp/cproot -cvf - . 2>/dev/null | tar -C /mnt -xf -	2>/dev/null
+    echo "Copy process complete"
 
-    # Unmount the new overlay and temporary mount point
+    echo "Unmounting new overlay and removing bind"
     umount /tmp/cproot /mnt
+
+    sleep 3
+}
+
+function finalize {
+    /usr/bin/dialog --title "Extroot: Info" --msgbox "::: NOTICE :::\n\nOperation complete. To finalize changes, the system will now reboot." 14 72
+    reboot
+}
+
+function perform_step {
+    # Create a tmpfile in which we can store error data
+    active_tmpfile=$(mktemp)
+    # Default error data to 0
+    echo 0 > $active_tmpfile
+
+    # Perform the requested step
+    eval $1 | /usr/bin/dialog --progressbox "$2" 14 72
+
+    # Retrieve the last error written to the tmpfile
+    last_return_code=$(cat $active_tmpfile)
+    # Delete the tmpfile
+    rm $active_tmpfile
+
+    # Determine if an error occurred
+    if [[ "$last_return_code" != 0 ]]; then
+        # Notify the user of the problem
+        /usr/bin/dialog --title "Extroot: Error" --msgbox "$last_return_code" 9 72
+        exit 1
+    fi
 }
 
 function perform_migration {
-    check_network
 
-    install_dependencies
+    perform_step "check_network" "Checking network connectivity"
 
-    remount_rootfsdata
+    perform_step "install_dependencies" "Installing requried dependencies"
 
-    format_sdcard
+    perform_step "remount_rootfsdata" "Creating backup mount for current overlay"
 
-    make_extroot
+    perform_step "format_sdcard" "Formatting SD card"
 
-    migrate_overlay
+    perform_step "make_extroot" "Configuring new overlay"
 
-    reboot
+    perform_step "migrate_overlay" "Migrating overlay data"
+
+    finalize
 }
 
 function start {

--- a/modules/extroot
+++ b/modules/extroot
@@ -23,18 +23,18 @@ CONF=/tmp/extroot.form
 : ${DIALOG_ESC=255}
 
 function configure {
-    /usr/bin/dialog --title "Extroot: Info" --msgbox "::: NOTICE :::\n\nThis module is intended for use on freshly-imaged devices. Any customizations already made are not guaranteed to persist through extroot configuration." 14 72
+    dialog --title "Extroot: Info" --msgbox "::: NOTICE :::\n\nThis module is intended for use on freshly-imaged devices. Any customizations already made are not guaranteed to persist through extroot configuration." 14 72
 
-    /usr/bin/dialog --title "Extroot: WARNING" --defaultno --yesno "::: WARNING :::\n\n\nThis Operation WILL ERASE THE ATTACHED SD CARD \n\nAre you sure you wish to continue?" 14 72
+    dialog --title "Extroot: WARNING" --defaultno --yesno "::: WARNING :::\n\n\nThis Operation WILL ERASE THE ATTACHED SD CARD \n\nAre you sure you wish to continue?" 14 72
 
     return=$?
     case $return in
       $DIALOG_OK)
         perform_migration;;
       $DIALOG_CANCEL)
-        /usr/bin/dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
+        dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
       $DIALOG_ESC)
-        /usr/bin/dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
+        dialog --title "Extroot" --msgbox "Operation cancelled" 14 72;;
     esac
 }
 
@@ -59,10 +59,10 @@ function check_network {
 
 function install_dependencies {
     echo "Updating opkg"
-    /bin/opkg update
+    opkg update
 
     echo "Checking/installing dependencies"
-    /bin/opkg install $REQUIRED_PACKAGES
+    opkg install $REQUIRED_PACKAGES
 
     sleep 3
 }
@@ -156,7 +156,7 @@ function migrate_overlay {
 }
 
 function finalize {
-    /usr/bin/dialog --title "Extroot: Info" --msgbox "::: NOTICE :::\n\nOperation complete. To finalize changes, the system will now reboot." 14 72
+    dialog --title "Extroot: Info" --msgbox "::: NOTICE :::\n\nOperation complete. To finalize changes, the system will now reboot." 14 72
     reboot
 }
 
@@ -167,7 +167,7 @@ function perform_step {
     echo 0 > $active_tmpfile
 
     # Perform the requested step
-    eval $1 | /usr/bin/dialog --progressbox "$2" 14 72
+    eval $1 | dialog --progressbox "$2" 14 72
 
     # Retrieve the last error written to the tmpfile
     last_return_code=$(cat $active_tmpfile)
@@ -177,7 +177,7 @@ function perform_step {
     # Determine if an error occurred
     if [[ "$last_return_code" != 0 ]]; then
         # Notify the user of the problem
-        /usr/bin/dialog --title "Extroot: Error" --msgbox "$last_return_code" 9 72
+        dialog --title "Extroot: Error" --msgbox "$last_return_code" 9 72
         exit 1
     fi
 }

--- a/modules/extroot
+++ b/modules/extroot
@@ -29,12 +29,12 @@ function configure {
 
     return=$?
     case $return in
-      $DIALOG_OK)
+      "$DIALOG_OK")
         perform_migration;;
-      $DIALOG_CANCEL)
+      "$DIALOG_CANCEL")
         dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
         exit 0;;
-      $DIALOG_ESC)
+      "$DIALOG_ESC")
         dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
         exit 0;;
     esac
@@ -51,12 +51,12 @@ function check_space {
         
         return=$?
         case $return in
-          $DIALOG_OK)
+          "$DIALOG_OK")
             return 0;;
-          $DIALOG_CANCEL)
+          "$DIALOG_CANCEL")
             dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
             exit 0;;
-          $DIALOG_ESC)
+          "$DIALOG_ESC")
             dialog --title "Extroot" --msgbox "Operation cancelled" 14 72
             exit 0;;
         esac
@@ -120,9 +120,9 @@ function format_sdcard {
     block umount &> /dev/null
 
     echo "Partitioning SD card"
-    echo -e "o\nn\np\n2\n\n+1024M\nn\np\n1\n\np\n\nw\n" | fdisk $sdcard_device 2>/dev/null
-    mkfs.ext4 -F ${sdcard_device}1
-    mkswap ${sdcard_device}2
+    echo -e "o\nn\np\n2\n\n+1024M\nn\np\n1\n\np\n\nw\n" | fdisk "$sdcard_device" 2>/dev/null
+    mkfs.ext4 -F "${sdcard_device}1"
+    mkswap "${sdcard_device}2"
 
     echo "Restarting the storage bus"
     echo "1-0:1.0" > /sys/bus/usb/drivers/hub/unbind 2>/dev/null
@@ -142,7 +142,7 @@ function make_extroot {
     sdcard_device=$(ls /dev/sd* 2> /dev/null | head -n1)1
     echo "New overlay partition identified as: $sdcard_device"
 
-    eval $(block info ${sdcard_device} | grep -o -e "UUID=\S*")
+    eval $(block info "${sdcard_device}" | grep -o -e "UUID=\S*")
     echo "New overlay partition has a UUID of: $UUID"
 
     echo "Recreating overlay fstab entry"
@@ -166,7 +166,7 @@ function migrate_overlay {
     mount --bind /overlay /tmp/cproot
 
     echo "Mounting new overlay parition at: /mnt"
-    mount ${sdcard_device} /mnt
+    mount "${sdcard_device}" /mnt
 
     echo "Copying data; please wait..."
     tar -C /tmp/cproot -cvf - . 2>/dev/null | tar -C /mnt -xf -	2>/dev/null
@@ -187,15 +187,15 @@ function perform_step {
     # Create a tmpfile in which we can store error data
     active_tmpfile=$(mktemp)
     # Default error data to 0
-    echo 0 > $active_tmpfile
+    echo 0 > "$active_tmpfile"
 
     # Perform the requested step
-    eval $1 | dialog --progressbox "$2" 14 72
+    eval "$1" | dialog --progressbox "$2" 14 72
 
     # Retrieve the last error written to the tmpfile
-    last_return_code=$(cat $active_tmpfile)
+    last_return_code=$(cat "$active_tmpfile")
     # Delete the tmpfile
-    rm $active_tmpfile
+    rm "$active_tmpfile"
 
     # Determine if an error occurred
     if [[ "$last_return_code" != 0 ]]; then

--- a/modules/extroot
+++ b/modules/extroot
@@ -80,6 +80,8 @@ function check_network {
         echo "\nLAN Turtle could not connect to $opkg_baseurl\nVerify the device's internet connection and try again (wget error $wget_returncode)" > $1
         return 1
     fi
+
+    sleep 3
 }
 
 function install_dependencies {
@@ -190,7 +192,7 @@ function perform_step {
     echo 0 > "$active_tmpfile"
 
     # Perform the requested step
-    eval "$1" | dialog --progressbox "$2" 14 72
+    eval "$1" "$active_tmpfile" | dialog --progressbox "$2" 14 72
 
     # Retrieve the last error written to the tmpfile
     last_return_code=$(cat "$active_tmpfile")

--- a/modules/module_list
+++ b/modules/module_list
@@ -2,6 +2,7 @@ autossh Maintain persistent secure shells
 cron Schedule tasks
 dns-spoof Forges replies to arbitrary DNS address
 dnsmasq-spoof DNSSpoof using DNSMasq
+extroot Simplified SD card storage
 follow-file Follow log printing data as file grows
 keymanager SSH Key Manager
 meterpreter Metasploit payload to maintain shells


### PR DESCRIPTION
Based off [this guide](https://openwrt.org/docs/guide-user/additional-software/extroot_configuration) from the OpenWRT documentation, extroot is a module meant to simplify SD card storage integration for fresh LAN Turtle installations.

In short, the filesystem overlay used to record changes beyond the base image is moved off onboard flash storage and onto the inserted SD card.

This module has been tested and verified against fresh installations running the v6.2 firmware.