### PR TITLE
First create the .ssh directory if it doesn't exist.

### DIFF
--- a/modules/autossh
+++ b/modules/autossh
@@ -13,7 +13,7 @@ CONF=/tmp/autossh.form
 
 function start {
   autossh_host=$(uci show autossh.@autossh[0].ssh | awk '{print $7}' | sed 's/@/ /g' | awk '{print $2}')
-  touch /root/.ssh/known_hosts
+  mkdir -p /root.ssh && touch /root/.ssh/known_hosts
   if grep $autossh_host /root/.ssh/known_hosts; then
     /etc/init.d/autossh start
   else


### PR DESCRIPTION
If no .ssh directory has yet been created, starting autossh throws an error:
```shell
touch: /root/.ssh/known_hosts: No such file or directory
```

Subsequently, the grep command also fails:
```shell
grep: /root/.ssh/known_hosts: No such file or directory
```

This commit will ensure the .ssh directory exists before attempting to touch known_hosts.